### PR TITLE
New update erroneous date

### DIFF
--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -135,8 +135,8 @@ update_error_indicators1 <- function(i, augmented_data, observed_dates, group,
 
 
 # Sample new date using randomly selected delay
-sample_from_delay <- function(i, estimated_dates, group, model_info,
-                              rng) {
+sample_from_delay <- function(i, estimated_dates, error_indicators, group,
+                              model_info, rng) {
   
   is_date_in_delay <- model_info$is_date_in_delay[i, , group]
   
@@ -146,12 +146,19 @@ sample_from_delay <- function(i, estimated_dates, group, model_info,
                            model_info$delay_from[which_delays], 
                            model_info$delay_to[which_delays])
   
-  ## Filter to only delays where the other date is available (needed for swap)
+  ## Filter to delays where the other date is available (needed for swap)
   valid_delays <- which_delays[!is.na(estimated_dates[other_date_idx])]
   other_date_idx <- other_date_idx[!is.na(estimated_dates[other_date_idx])]
   
+  ## Of the valid delays, prioritise those where the other date is "correct"
+  is_correct <- !is.na(error_indicators[other_date_idx]) &
+    !error_indicators[other_date_idx]
+  if (any(is_correct)) {
+    valid_delays <- valid_delays[is_correct]
+    other_date_idx <- other_date_idx[is_correct]
+  }
   
-  ## If it is involved in several delays, randomly select one
+  ## Randomly select from the valid delays
   delay_idx <- if (length(valid_delays) == 1) 1 else 
     ceiling(length(valid_delays) * monty::monty_random_real(rng))
   selected_delay <- valid_delays[delay_idx]

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -319,7 +319,7 @@ calc_accept_prob <- function(updated, augmented_data_new, augmented_data,
     model_info$delay_cv, model_info$delay_from, model_info$delay_to,
     model_info$delay_distribution, is_delay_in_group)
   
-  if (any(is.infinite(ll_delays_new))) {
+  if (any(!is.finite(ll_delays_new))) {
     ## Covering two cases here:
     ## 1. a proposed delay is negative so we want to auto-reject
     ## 2. we have ended up in a situation that such a small delay has been drawn
@@ -355,7 +355,7 @@ calc_accept_prob <- function(updated, augmented_data_new, augmented_data,
   ratio_post <- ratio_ll_delays + ratio_ll_errors
 
   ## No need to calculate proposal correction if ratio_post is -Inf
-  if (ratio_post == -Inf) {
+  if (is.na(ratio_post) || ratio_post == -Inf) {
     return(-Inf)
   }
   
@@ -363,7 +363,10 @@ calc_accept_prob <- function(updated, augmented_data_new, augmented_data,
     calc_proposal_density(updated, augmented_data, group, model_info, is_batch)
   prop_new <- 
     calc_proposal_density(updated, augmented_data_new, group, model_info, is_batch)
+  
   ratio_prop <- prop_current - prop_new
+  
+  if (is.na(ratio_prop)) return(-Inf)
   
   ratio_post + ratio_prop
 }

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -69,13 +69,25 @@ update_estimated_dates1 <- function(i, augmented_data, observed_dates, group,
     return(augmented_data)
   }
   
+  ## Also update any dates connected to i that are erroneous or missing to
+  ## ensure that they stay consistent with the newly proposed date
+  is_date_connected <- model_info$is_date_connected[, , group]
+  connected_to_i <- which(is_date_connected[i, ])
+  err_ind <- augmented_data$error_indicators
+  
+  connected_missing_or_error <- connected_to_i[
+    is.na(err_ind[connected_to_i]) | isTRUE(err_ind[connected_to_i])
+  ]
+  
+  to_update <- c(i, connected_missing_or_error)
+  
   augmented_data_new <- 
-    propose_estimated_dates(i, augmented_data, observed_dates, group,
+    propose_estimated_dates(to_update, augmented_data, observed_dates, group,
                             model_info, rng)
   
   accept_prob <-
-    calc_accept_prob(i, augmented_data_new, augmented_data, observed_dates,
-                     group, prob_error, model_info, date_range)
+    calc_accept_prob(to_update, augmented_data_new, augmented_data,
+                     observed_dates, group, prob_error, model_info, date_range)
 
   accept <- log(monty::monty_random_real(rng)) < accept_prob
   if (accept) {

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -76,7 +76,7 @@ update_estimated_dates1 <- function(i, augmented_data, observed_dates, group,
   err_ind <- augmented_data$error_indicators
   
   connected_missing_or_error <- connected_to_i[
-    is.na(err_ind[connected_to_i]) | isTRUE(err_ind[connected_to_i])
+    is.na(err_ind[connected_to_i]) | err_ind[connected_to_i]
   ]
   
   to_update <- c(i, connected_missing_or_error)

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -69,26 +69,15 @@ update_estimated_dates1 <- function(i, augmented_data, observed_dates, group,
     return(augmented_data)
   }
   
-  ## Also update any dates connected to i that are erroneous or missing to
-  ## ensure that they stay consistent with the newly proposed date
-  is_date_connected <- model_info$is_date_connected[, , group]
-  connected_to_i <- which(is_date_connected[i, ])
-  err_ind <- augmented_data$error_indicators
-  
-  connected_missing_or_error <- connected_to_i[
-    is.na(err_ind[connected_to_i]) | err_ind[connected_to_i]
-  ]
-  
-  to_update <- c(i, connected_missing_or_error)
-  
-  augmented_data_new <- 
-    propose_estimated_dates(to_update, augmented_data, observed_dates, group,
-                            model_info, rng)
+  proposed <- propose_estimated_dates(i, augmented_data, observed_dates, group,
+                                      model_info, rng)
+  augmented_data_new <- proposed$augmented_data
+  updated <- proposed$updated
   
   accept_prob <-
-    calc_accept_prob(to_update, augmented_data_new, augmented_data,
+    calc_accept_prob(updated, augmented_data_new, augmented_data,
                      observed_dates, group, prob_error, model_info, date_range)
-
+  
   accept <- log(monty::monty_random_real(rng)) < accept_prob
   if (accept) {
     augmented_data <- augmented_data_new
@@ -131,7 +120,7 @@ update_error_indicators1 <- function(i, augmented_data, observed_dates, group,
   
   augmented_data_new <- 
     propose_estimated_dates(i, augmented_data, observed_dates, group,
-                            model_info, rng, TRUE)
+                            model_info, rng, TRUE)$augmented_data
   
   accept_prob <-
     calc_accept_prob(i, augmented_data_new, augmented_data, observed_dates,
@@ -229,25 +218,55 @@ propose_estimated_dates <- function(to_update, augmented_data, observed_dates,
       !augmented_data$error_indicators[to_update]
   }
   
-  augmented_data$estimated_dates[to_update] <- NA
+  is_date_in_group <- model_info$is_date_in_group[, group]
+  is_date_connected <- model_info$is_date_connected[, , group]
   
-  resampling_order <- 
-    calc_resampling_order(to_update, augmented_data$error_indicators,
-                          model_info$is_date_connected[, , group])
+  ## Queue starts with the originally requested dates. When updating a
+  ## single date, connected missing/erroneous dates are added to the queue
+  ## sequentially
+  queue <- to_update
+  sampled <- integer(0)
+  cascade <- length(to_update) == 1
   
-  for (i in resampling_order) {
+  while (length(queue) > 0) {
+    
+    ## Set current queue to NA and determine resampling order. Dates
+    ## outside the queue retain their current values as anchors
+    augmented_data$estimated_dates[queue] <- NA
+    resampling_order <- calc_resampling_order(queue,
+                                              augmented_data$error_indicators,
+                                              is_date_connected)
+  
+    ## Take next date in order, resample it
+    i <- resampling_order[1]
+    
     if (isFALSE(augmented_data$error_indicators[i])) {
       augmented_data$estimated_dates[i] <-
         observed_dates[i] + monty::monty_random_real(rng)
     } else {
       augmented_data$estimated_dates[i] <-
-        sample_from_delay(i, augmented_data$estimated_dates, 
+        sample_from_delay(i, augmented_data$estimated_dates,
                           augmented_data$error_indicators, group,
                           model_info, rng)
     }
+    
+    sampled <- c(sampled, i)
+    queue <- queue[-match(i, queue)]
+    
+    ## Cascade: find dates connected to i that are missing/erroneous and
+    ## not yet sampled or already queued
+    if (cascade) {
+      err_ind <- augmented_data$error_indicators
+      connected_to_i <- which(is_date_connected[i, ] & is_date_in_group)
+      newly_found <- connected_to_i[
+        (is.na(err_ind[connected_to_i]) | err_ind[connected_to_i]) &
+          !(connected_to_i %in% c(sampled, queue))
+      ]
+      queue <- c(queue, newly_found)
+    }
   }
   
-  augmented_data
+  list(augmented_data = augmented_data, updated = sampled)
 }
 
 
@@ -432,7 +451,7 @@ swap_error_indicators <- function(augmented_data, observed_dates, group,
   # systematically sample new errors and missing dates based on new non-errors
   augmented_data_new <- 
     propose_estimated_dates(event_order, augmented_data, observed_dates, group,
-                            model_info, rng, TRUE)
+                            model_info, rng, TRUE)$augmented_data
 
   accept_prob <-
     calc_accept_prob(event_order, augmented_data_new, augmented_data,

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -76,7 +76,8 @@ update_estimated_dates1 <- function(i, augmented_data, observed_dates, group,
   
   accept_prob <-
     calc_accept_prob(updated, augmented_data_new, augmented_data,
-                     observed_dates, group, prob_error, model_info, date_range)
+                     observed_dates, group, prob_error, model_info, date_range,
+                     is_batch = FALSE)
   
   accept <- log(monty::monty_random_real(rng)) < accept_prob
   if (accept) {
@@ -118,13 +119,16 @@ update_error_indicators1 <- function(i, augmented_data, observed_dates, group,
     return(augmented_data)
   }
   
-  augmented_data_new <- 
+  proposed <- 
     propose_estimated_dates(i, augmented_data, observed_dates, group,
-                            model_info, rng, TRUE)$augmented_data
+                            model_info, rng, TRUE)
+  
+  augmented_data_new <- proposed$augmented_data
+  updated <- proposed$updated
   
   accept_prob <-
-    calc_accept_prob(i, augmented_data_new, augmented_data, observed_dates,
-                     group, prob_error, model_info, date_range)
+    calc_accept_prob(updated, augmented_data_new, augmented_data, observed_dates,
+                     group, prob_error, model_info, date_range, is_batch = FALSE)
 
   accept <- log(monty::monty_random_real(rng)) < accept_prob
   if (accept) {
@@ -221,41 +225,57 @@ propose_estimated_dates <- function(to_update, augmented_data, observed_dates,
   is_date_in_group <- model_info$is_date_in_group[, group]
   is_date_connected <- model_info$is_date_connected[, , group]
   
-  ## Queue starts with the originally requested dates. When updating a
-  ## single date, connected missing/erroneous dates are added to the queue
-  ## sequentially
-  queue <- to_update
   sampled <- integer(0)
   cascade <- length(to_update) == 1
   
-  while (length(queue) > 0) {
+  if (!cascade) {
+    # Updating batches e.g. swaps
+    # Calculating the order once for the entire batch to preserve anchors
+    augmented_data$estimated_dates[to_update] <- NA
+    resampling_order <- calc_batch_resampling_order(
+      to_update,
+      augmented_data$error_indicators,
+      is_date_connected
+      )
     
-    ## Set current queue to NA and determine resampling order. Dates
-    ## outside the queue retain their current values as anchors
-    augmented_data$estimated_dates[queue] <- NA
-    resampling_order <- calc_resampling_order(queue,
-                                              augmented_data$error_indicators,
-                                              is_date_connected)
-  
-    ## Take next date in order, resample it
-    i <- resampling_order[1]
-    
-    if (isFALSE(augmented_data$error_indicators[i])) {
-      augmented_data$estimated_dates[i] <-
-        observed_dates[i] + monty::monty_random_real(rng)
-    } else {
-      augmented_data$estimated_dates[i] <-
-        sample_from_delay(i, augmented_data$estimated_dates,
-                          augmented_data$error_indicators, group,
-                          model_info, rng)
+    for (i in resampling_order) {
+      if (isFALSE(augmented_data$error_indicators[i])) {
+        # sample correct date uniformly
+        augmented_data$estimated_dates[i] <-
+          observed_dates[i] + monty::monty_random_real(rng)
+      } else {
+        # sample error/missing dates from delays
+        augmented_data$estimated_dates[i] <-
+          sample_from_delay(i, augmented_data$estimated_dates, 
+                            augmented_data$error_indicators, group,
+                            model_info, rng)
+      }
+      sampled <- c(sampled, i)
     }
     
-    sampled <- c(sampled, i)
-    queue <- queue[-match(i, queue)]
+  } else {
+    # Updating single dates and connected missing/erroneous dates
+    queue <- to_update
     
-    ## Cascade: find dates connected to i that are missing/erroneous and
-    ## not yet sampled or already queued
-    if (cascade) {
+    while (length(queue) > 0) {
+      i <- queue[1]
+      augmented_data$estimated_dates[i] <- NA
+      
+      if (isFALSE(augmented_data$error_indicators[i])) {
+        augmented_data$estimated_dates[i] <-
+          observed_dates[i] + monty::monty_random_real(rng)
+      } else {
+        augmented_data$estimated_dates[i] <-
+          sample_from_delay(i, augmented_data$estimated_dates,
+                            augmented_data$error_indicators, group,
+                            model_info, rng)
+      }
+    
+      sampled <- c(sampled, i)
+      queue <- queue[-1]
+      
+      ## Cascade: find dates connected to i that are missing/erroneous and
+      ## not yet sampled or already queued
       err_ind <- augmented_data$error_indicators
       connected_to_i <- which(is_date_connected[i, ] & is_date_in_group)
       newly_found <- connected_to_i[
@@ -274,7 +294,7 @@ propose_estimated_dates <- function(to_update, augmented_data, observed_dates,
 ## augmented_data_new where updated is the indices of the updated date(s)
 calc_accept_prob <- function(updated, augmented_data_new, augmented_data,
                              observed_dates, group, prob_error, model_info,
-                             date_range) {
+                             date_range, is_batch = FALSE) {
   
   is_delay_in_group <- model_info$is_delay_in_group[, group]
 
@@ -302,7 +322,7 @@ calc_accept_prob <- function(updated, augmented_data_new, augmented_data,
   if (any(is.infinite(ll_delays_new))) {
     ## Covering two cases here:
     ## 1. a proposed delay is negative so we want to auto-reject
-    ## 2. we haveended up in a situation that such a small delay has been drawn
+    ## 2. we have ended up in a situation that such a small delay has been drawn
     ##    that when recalculated from the dates it is essentially 0 and 
     ##    distribution has infinite density at 0 (CV > 1). Let's reject for
     ##    the moment
@@ -340,27 +360,36 @@ calc_accept_prob <- function(updated, augmented_data_new, augmented_data,
   }
   
   prop_current <- 
-    calc_proposal_density(updated, augmented_data, group, model_info)
+    calc_proposal_density(updated, augmented_data, group, model_info, is_batch)
   prop_new <- 
-    calc_proposal_density(updated, augmented_data_new, group, model_info)
+    calc_proposal_density(updated, augmented_data_new, group, model_info, is_batch)
   ratio_prop <- prop_current - prop_new
   
   ratio_post + ratio_prop
 }
 
 
-calc_proposal_density <- function(updated, augmented_data, group, model_info) {
+calc_proposal_density <- function(updated, augmented_data, group, model_info,
+                                  is_batch = FALSE) {
   
   is_date_in_delay <- model_info$is_date_in_delay[, , group]
   is_date_in_group <- model_info$is_date_in_group[, group]
   is_date_connected <- model_info$is_date_connected[, , group]
   
-  resampling_order <- 
-    calc_resampling_order(updated, augmented_data$error_indicators,
-                          is_date_connected)
-  
-  is_updated <- seq_along(augmented_data$error_indicators) %in% updated
-  available_dates <- which(is_date_in_group & !is_updated)
+  if (is_batch) {
+    resampling_order <- calc_batch_resampling_order(updated,
+                                                   augmented_data$error_indicators,
+                                                   is_date_connected)
+    # in the batch case all dates in `updated` are cleared to NA upfront before
+    # any sampling happens - so only dates not in `updated` are available as anchors
+    is_updated <- seq_along(augmented_data$error_indicators) %in% updated
+    available_dates <- which(is_date_in_group & !is_updated)
+  } else {
+    resampling_order <- calc_cascade_resampling_order(updated, is_date_connected)
+    # in  the cascade case, only one date is cleared at a time - all other dates
+    # have their values from the previous iteration and can be used as anchors
+    available_dates <- which(is_date_in_group)
+  }
   
   d <- rep(0, length(updated))
   
@@ -455,7 +484,8 @@ swap_error_indicators <- function(augmented_data, observed_dates, group,
 
   accept_prob <-
     calc_accept_prob(event_order, augmented_data_new, augmented_data,
-                     observed_dates, group, prob_error, model_info, date_range)
+                     observed_dates, group, prob_error, model_info, date_range,
+                     is_batch = TRUE)
   
   accept <- log(monty::monty_random_real(rng)) < accept_prob
   if (accept) {
@@ -467,12 +497,10 @@ swap_error_indicators <- function(augmented_data, observed_dates, group,
 }
 
 
-calc_resampling_order <- function(to_resample, error_indicators,
-                                  is_date_connected) {
+calc_batch_resampling_order <- function(to_resample, error_indicators,
+                                       is_date_connected) {
   
-  if (length(to_resample) == 1) {
-    return(to_resample)
-  }
+  if (length(to_resample) == 1) return(to_resample)
   
   ## resample non-errors first
   err_ind <- error_indicators[to_resample]
@@ -482,14 +510,13 @@ calc_resampling_order <- function(to_resample, error_indicators,
   remaining_to_resample <- to_resample[!is_non_error]
   
   if (length(remaining_to_resample) > 0) {
-    
     while (length(remaining_to_resample) > 1) {
       # Find all dates connected to available dates
       is_connected <- 
         rowSums(is_date_connected[remaining_to_resample, resampling_order,
                                   drop = FALSE]) > 0
       connected_dates <- remaining_to_resample[is_connected]
-      
+
       # Earliest connected event according to resampling_order
       earliest_idx <- which(remaining_to_resample %in% connected_dates)[1]
       date_to_sample <- remaining_to_resample[earliest_idx]
@@ -498,7 +525,35 @@ calc_resampling_order <- function(to_resample, error_indicators,
       resampling_order <- c(resampling_order, date_to_sample)
       remaining_to_resample <- remaining_to_resample[-earliest_idx]
     }
-    
+    resampling_order <- c(resampling_order, remaining_to_resample)
+  }
+  
+  resampling_order
+}
+
+
+calc_cascade_resampling_order <- function(to_resample, is_date_connected) {
+  
+  if (length(to_resample) == 1) return(to_resample)
+  
+  ## In a cascade, the index of the single date being updated is the starting
+  ## point for resampling the connected dates
+  resampling_order <- to_resample[1]
+  remaining_to_resample <- to_resample[-1]
+  
+  if (length(remaining_to_resample) > 0) {
+    while (length(remaining_to_resample) > 1) {
+      is_connected <- 
+        rowSums(is_date_connected[remaining_to_resample, resampling_order,
+                                  drop = FALSE]) > 0
+      connected_dates <- remaining_to_resample[is_connected]
+      
+      earliest_idx <- which(remaining_to_resample %in% connected_dates)[1]
+      date_to_sample <- remaining_to_resample[earliest_idx]
+      
+      resampling_order <- c(resampling_order, date_to_sample)
+      remaining_to_resample <- remaining_to_resample[-earliest_idx]
+    }
     resampling_order <- c(resampling_order, remaining_to_resample)
   }
   

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -229,7 +229,8 @@ propose_estimated_dates <- function(to_update, augmented_data, observed_dates,
         observed_dates[i] + monty::monty_random_real(rng)
     } else {
       augmented_data$estimated_dates[i] <-
-        sample_from_delay(i, augmented_data$estimated_dates, group,
+        sample_from_delay(i, augmented_data$estimated_dates, 
+                          augmented_data$error_indicators, group,
                           model_info, rng)
     }
   }

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -340,7 +340,6 @@ calc_proposal_density <- function(updated, augmented_data, group, model_info) {
     calc_resampling_order(updated, augmented_data$error_indicators,
                           is_date_connected)
   
-  dates <- which(is_date_in_group)
   is_updated <- seq_along(augmented_data$error_indicators) %in% updated
   available_dates <- which(is_date_in_group & !is_updated)
   
@@ -354,14 +353,27 @@ calc_proposal_density <- function(updated, augmented_data, group, model_info) {
     ## is 0, hence only need to calculate for error (TRUE) or missing (NA)
     
     if (!isFALSE(augmented_data$error_indicators[i])) {
-      ## which dates were available for sampling
+      
+      ## which delays have at least one available "other" date
       is_delay_available <- 
         colSums(is_date_in_delay[available_dates, , drop = FALSE]) > 0
-      ## which delays could be sampled from
-      can_sample_from_delay <- is_date_in_delay[i, ] & 
-        is_delay_available
+      can_sample_from_delay <- is_date_in_delay[i, ] & is_delay_available
       
-      ## error or missing - proposal is based on delay(s)
+      ## idx for "other" date in each valid delay
+      other_date_idx <- ifelse(
+        model_info$delay_from[can_sample_from_delay] != i,
+        model_info$delay_from[can_sample_from_delay],
+        model_info$delay_to[can_sample_from_delay]
+      )
+      
+      ## "correct" connected dates are prioritised
+      err_ind <- augmented_data$error_indicators
+      is_correct_other <- !is.na(err_ind[other_date_idx]) &
+        !err_ind[other_date_idx]
+      if (any(is_correct_other)) {
+        can_sample_from_delay[can_sample_from_delay] <- is_correct_other
+      }
+      
       delay_cv <- model_info$delay_cv[can_sample_from_delay]
       delay_mean <- model_info$delay_mean[can_sample_from_delay]
       delay_distribution <- model_info$delay_distribution[can_sample_from_delay]

--- a/tests/testthat/test-mcmc-augmented-data-update.R
+++ b/tests/testthat/test-mcmc-augmented-data-update.R
@@ -136,6 +136,12 @@ test_that("updating error indicator cascades to connected dates", {
   augmented_data_proposed <- proposed$augmented_data
   updated_dates <- proposed$updated
   
+  # check proposal
+  expect_true(augmented_data_proposed$error_indicators[i])
+  expect_true(augmented_data_proposed$estimated_dates[i] !=
+                augmented_data$estimated_dates[i])
+  expect_true(all(c(1, 4) %in% updated_dates))
+  
   accept_prob <- calc_accept_prob(updated_dates, augmented_data_proposed,
                                   augmented_data, observed_dates, group,
                                   prob_error, model_info, date_range)
@@ -171,6 +177,11 @@ test_that("updating error indicator cascades to connected dates", {
   augmented_data_proposed <- proposed$augmented_data
   updated_dates <- proposed$updated
   
+  # check proposal
+  expect_false(augmented_data_proposed$error_indicators[i])
+  expect_equal(floor(augmented_data_proposed$estimated_dates[i]), observed_dates[i])
+  expect_true(1 %in% updated_dates)
+  
   accept_prob <- calc_accept_prob(updated_dates, augmented_data_proposed,
                                   augmented_data, observed_dates, group,
                                   prob_error, model_info, date_range)
@@ -205,6 +216,12 @@ test_that("updating error indicator cascades to connected dates", {
                                       model_info, rng1, update_errors = TRUE)
   augmented_data_proposed <- proposed$augmented_data
   updated_dates <- proposed$updated
+  
+  # check proposal
+  expect_false(augmented_data_proposed$error_indicators[i])
+  expect_equal(floor(augmented_data_proposed$estimated_dates[i]), observed_dates[i])
+  expect_true(4 %in% updated_dates) # death date 4 is missing so should update
+  expect_false(1 %in% updated_dates) # onset date 1 is correct (no update)
   
   accept_prob <- calc_accept_prob(updated_dates, augmented_data_proposed,
                                   augmented_data, observed_dates, group,

--- a/tests/testthat/test-mcmc-augmented-data-update.R
+++ b/tests/testthat/test-mcmc-augmented-data-update.R
@@ -1,4 +1,4 @@
-test_that("resampling order calculated correctly", {
+test_that("batch resampling order calculated correctly", {
   delay_map <- toy_model()$delay_map
   dates <- c("onset", "hospitalisation", "report", "death", "discharge")
   model_info <- make_model_info(delay_map, dates)
@@ -9,31 +9,337 @@ test_that("resampling order calculated correctly", {
   ## the order in to_resample and whether or not errors or missing dates have
   ## delay-connected dates to use for sampling
   expect_equal(
-    calc_resampling_order(c(1, 3), c(FALSE, NA, TRUE, NA, NA),
-                          model_info$is_date_connected[, , 1]), c(1, 3))
+    calc_batch_resampling_order(c(1, 3), c(FALSE, NA, TRUE, NA, NA),
+                               model_info$is_date_connected[, , 1]), c(1, 3))
   expect_equal(
-    calc_resampling_order(c(1, 3), c(TRUE, NA, FALSE, NA, NA),
+    calc_batch_resampling_order(c(1, 3), c(TRUE, NA, FALSE, NA, NA),
                           model_info$is_date_connected[, , 1]), c(3, 1))
   expect_equal(
-    calc_resampling_order(c(1, 4, 3), c(TRUE, NA, FALSE, FALSE, NA),
+    calc_batch_resampling_order(c(1, 4, 3), c(TRUE, NA, FALSE, FALSE, NA),
                           model_info$is_date_connected[, , 2]), c(4, 3, 1))
   expect_equal(
-    calc_resampling_order(c(1, 4, 3), c(FALSE, NA, TRUE, TRUE, NA),
+    calc_batch_resampling_order(c(1, 4, 3), c(FALSE, NA, TRUE, TRUE, NA),
                           model_info$is_date_connected[, , 2]), c(1, 4, 3))
   expect_equal(
-    calc_resampling_order(c(1, 4, 3), c(TRUE, NA, FALSE, NA, NA),
+    calc_batch_resampling_order(c(1, 4, 3), c(TRUE, NA, FALSE, NA, NA),
                           model_info$is_date_connected[, , 2]), c(3, 1, 4))
   expect_equal(
-    calc_resampling_order(c(5, 3, 2, 1), c(TRUE, NA, FALSE, NA, TRUE),
+    calc_batch_resampling_order(c(5, 3, 2, 1), c(TRUE, NA, FALSE, NA, TRUE),
                           model_info$is_date_connected[, , 3]), c(3, 1, 2, 5))
   expect_equal(
-    calc_resampling_order(c(5, 3, 2, 1), c(FALSE, NA, TRUE, NA, FALSE),
+    calc_batch_resampling_order(c(5, 3, 2, 1), c(FALSE, NA, TRUE, NA, FALSE),
                           model_info$is_date_connected[, , 3]), c(5, 1, 3, 2))
   expect_equal(
-    calc_resampling_order(c(5, 3, 2, 1), c(TRUE, FALSE, FALSE, NA, NA),
+    calc_batch_resampling_order(c(5, 3, 2, 1), c(TRUE, FALSE, FALSE, NA, NA),
                           model_info$is_date_connected[, , 3]), c(3, 2, 5, 1))
 })
 
+test_that("cascade resampling order calculated correctly", {
+  delay_map <- toy_model()$delay_map
+  dates <- c("onset", "hospitalisation", "report", "death", "discharge")
+  model_info <- make_model_info(delay_map, dates)
+  
+  # group 2: onset(1) to report(3) and onset(1) to death(4)
+  # 3 and 4 NOT directly connected
+  
+  ## anchor = 3
+  ## 3 --> 1 --> 4
+  expect_equal(
+    calc_cascade_resampling_order(c(3, 1, 4),
+                                  model_info$is_date_connected[, , 2]),
+    c(3, 1, 4))
+  
+  ## same dates, different input order
+  expect_equal(
+    calc_cascade_resampling_order(c(3, 4, 1),
+                                  model_info$is_date_connected[, , 2]),
+    c(3, 1, 4))
+  
+  ## anchor = 4
+  ## 4 --> 1 --> 3
+  expect_equal(
+    calc_cascade_resampling_order(c(4, 3, 1),
+                                  model_info$is_date_connected[, , 2]),
+    c(4, 1, 3))
+  
+  ## anchor = 1
+  ## both 3 and 4 connected to 1, currently input order breaks the tie
+  expect_equal(
+    calc_cascade_resampling_order(c(1, 3, 4),
+                                  model_info$is_date_connected[, , 2]),
+    c(1, 3, 4))
+  expect_equal(
+    calc_cascade_resampling_order(c(1, 4, 3),
+                                  model_info$is_date_connected[, , 2]),
+    c(1, 4, 3))
+  
+  # group 4: onset(1) to hosp(2) and hosp(2) to death(4)
+  # 1 and 4 NOT directly connected
+  
+  ## anchor = 1
+  ## 1 --> 2 --> 4
+  expect_equal(
+    calc_cascade_resampling_order(c(1, 4, 2),
+                                  model_info$is_date_connected[, , 4]),
+    c(1, 2, 4))
+  
+  ## anchor = 4
+  ## 4 --> 2 --> 1
+  expect_equal(
+    calc_cascade_resampling_order(c(4, 1, 2),
+                                  model_info$is_date_connected[, , 4]),
+    c(4, 2, 1))
+  
+  ## anchor = 2
+  ## both 1 and 4 connected to 2, currently input order breaks the tie
+  expect_equal(
+    calc_cascade_resampling_order(c(2, 4, 1),
+                                  model_info$is_date_connected[, , 4]),
+    c(2, 4, 1))
+  expect_equal(
+    calc_cascade_resampling_order(c(2, 1, 4),
+                                  model_info$is_date_connected[, , 4]),
+    c(2, 1, 4))
+})
+
+test_that("updating error indicator cascades to connected dates", {
+  delay_map <- toy_model()$delay_map
+  dates <- c("onset", "hospitalisation", "report", "death", "discharge")
+  model_info <- make_model_info(delay_map, dates)
+  
+  model_info$delay_mean <- c(5, 8, 3, 4, 7, 10)
+  model_info$delay_cv <- c(0.5, 0.3, 0.2, 0.7, 0.6, 0.9)
+  
+  date_range <- c(0, 500)
+  prob_error <- 0.05
+  control <- mcmc_control(prob_update_error_indicators = 1)
+  
+  ## group 2, flip correct report (date 3) to error (FALSE --> TRUE)
+  ## onset (date 1) is missing and connected --> resampled
+  ## death (date 4) is error and connected via date 1 --> resampled
+  group <- 2
+  i <- 3
+  observed_dates <- c(NA, NA, 40, 68, NA)
+  augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
+                         error_indicators = c(NA, NA, FALSE, TRUE, NA))
+  
+  rng  <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
+  
+  augmented_data_new <-
+    update_error_indicators1(i, augmented_data, observed_dates, group,
+                             prob_error, model_info, date_range, control, rng)
+  
+  x <- monty::monty_random_real(rng1)
+  proposed <- propose_estimated_dates(i, augmented_data, observed_dates, group,
+                                      model_info, rng1, update_errors = TRUE)
+  augmented_data_proposed <- proposed$augmented_data
+  updated_dates <- proposed$updated
+  
+  accept_prob <- calc_accept_prob(updated_dates, augmented_data_proposed,
+                                  augmented_data, observed_dates, group,
+                                  prob_error, model_info, date_range)
+  accept <- log(monty::monty_random_real(rng1)) < accept_prob
+  
+  if (accept) {
+    expect_equal(augmented_data_new, augmented_data_proposed)
+    expect_true(augmented_data_new$error_indicators[3]) # error flipped
+  } else {
+    expect_equal(augmented_data_new, augmented_data)
+    expect_false(augmented_data_new$error_indicators[3])
+  }
+  expect_equal(monty::monty_rng_state(rng), monty::monty_rng_state(rng1))
+  
+  ## group 2, flip error death (date 4) to correct (TRUE --> FALSE)
+  ## onset (date 1) is missing and connected --> resampled
+  group <- 2
+  i <- 4
+  observed_dates <- c(NA, NA, 40, 68, NA)
+  augmented_data <- list(estimated_dates  = c(20.5, NA, 40.2, 50.1, NA),
+                         error_indicators = c(NA, NA, FALSE, TRUE, NA))
+  
+  rng <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
+  
+  augmented_data_new <-
+    update_error_indicators1(i, augmented_data, observed_dates, group,
+                             prob_error, model_info, date_range, control, rng)
+  
+  x <- monty::monty_random_real(rng1)
+  proposed <- propose_estimated_dates(i, augmented_data, observed_dates, group,
+                                      model_info, rng1, update_errors = TRUE)
+  augmented_data_proposed <- proposed$augmented_data
+  updated_dates <- proposed$updated
+  
+  accept_prob <- calc_accept_prob(updated_dates, augmented_data_proposed,
+                                  augmented_data, observed_dates, group,
+                                  prob_error, model_info, date_range)
+  accept <- log(monty::monty_random_real(rng1)) < accept_prob
+  
+  if (accept) {
+    expect_equal(augmented_data_new, augmented_data_proposed)
+    expect_false(augmented_data_new$error_indicators[4]) # error flipped
+  } else {
+    expect_equal(augmented_data_new, augmented_data)
+    expect_true(augmented_data_new$error_indicators[4])
+  }
+  expect_equal(monty::monty_rng_state(rng), monty::monty_rng_state(rng1))
+  
+  ## group 4, flip error hospitalisation (date 2) to correct (TRUE --> FALSE)
+  ## death (date 4) is missing and connected --> resampled
+  group <- 4
+  i <- 2
+  observed_dates <- c(10, 5, 30, NA, NA)
+  augmented_data <- list(estimated_dates = c(10.3, 15.4, 30.2, 40.1, NA),
+                         error_indicators = c(FALSE, TRUE, FALSE, NA, NA))
+  
+  rng <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
+  
+  augmented_data_new <-
+    update_error_indicators1(i, augmented_data, observed_dates, group,
+                             prob_error, model_info, date_range, control, rng)
+  
+  x <- monty::monty_random_real(rng1)
+  proposed <- propose_estimated_dates(i, augmented_data, observed_dates, group,
+                                      model_info, rng1, update_errors = TRUE)
+  augmented_data_proposed <- proposed$augmented_data
+  updated_dates <- proposed$updated
+  
+  accept_prob <- calc_accept_prob(updated_dates, augmented_data_proposed,
+                                  augmented_data, observed_dates, group,
+                                  prob_error, model_info, date_range)
+  accept <- log(monty::monty_random_real(rng1)) < accept_prob
+  
+  if (accept) {
+    expect_equal(augmented_data_new, augmented_data_proposed)
+    expect_false(augmented_data_new$error_indicators[2])
+  } else {
+    expect_equal(augmented_data_new, augmented_data)
+    expect_true(augmented_data_new$error_indicators[2])
+  }
+  expect_equal(monty::monty_rng_state(rng), monty::monty_rng_state(rng1))
+})
+
+test_that("updating estimated date cascades to connected missing/erroneous dates", {
+  delay_map <- toy_model()$delay_map
+  dates <- c("onset", "hospitalisation", "report", "death", "discharge")
+  model_info <- make_model_info(delay_map, dates)
+  
+  model_info$delay_mean <- c(5, 8, 3, 4, 7, 10)
+  model_info$delay_cv <- c(0.5, 0.3, 0.2, 0.7, 0.6, 0.9)
+  
+  date_range <- c(0, 500)
+  prob_error <- 0.05
+  control <- mcmc_control(prob_update_estimated_dates = 1)
+  
+  ## group 2, update correct report (date 3)
+  ## onset (date 1) is missing and connected to date 3 --> date 1 updated next
+  ## after date 1 is updated --> can update incorrect date 4
+  group <- 2
+  i <- 3
+  observed_dates <- c(NA, NA, 40, 68, NA)
+  augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
+                         error_indicators = c(NA, NA, FALSE, TRUE, NA))
+  
+  rng <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
+  
+  augmented_data_new <- 
+    update_estimated_dates1(i, augmented_data, observed_dates, group,
+                            prob_error, model_info, date_range, control, rng)
+  
+  ## manually replicate expected behaviour with rng1
+  x <- monty::monty_random_real(rng1)
+  
+  proposed <- propose_estimated_dates(i, augmented_data, observed_dates, group,
+                                      model_info, rng1, FALSE)
+  
+  augmented_data_proposed <- proposed$augmented_data
+  updated_dates <- proposed$updated
+  
+  accept_prob <- calc_accept_prob(updated_dates, augmented_data_proposed,
+                                  augmented_data, observed_dates, group,
+                                  prob_error, model_info, date_range)
+  accept <- log(monty::monty_random_real(rng1)) < accept_prob
+  
+  if (accept) {
+    expect_equal(augmented_data_new, augmented_data_proposed)
+  } else {
+    expect_equal(augmented_data_new, augmented_data)
+  }
+  expect_equal(monty::monty_rng_state(rng), monty::monty_rng_state(rng1))
+  
+  ## group 4, update correct onset (date 1)
+  ## hosp (date 2) is erroneous and connected --> date 2 updated next
+  ## date 4 connected and missing --> date 4 updated next
+  group <- 4
+  i <- 1
+  observed_dates <- c(10, 5, 30, NA, NA)
+  augmented_data <- list(estimated_dates = c(10.3, 15.4, 30.2, 40.1, NA),
+                         error_indicators = c(FALSE, TRUE, FALSE, NA, NA))
+  
+  rng <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
+  
+  augmented_data_new <- 
+    update_estimated_dates1(i, augmented_data, observed_dates, group,
+                            prob_error, model_info, date_range, control, rng)
+  
+  x <- monty::monty_random_real(rng1)
+  proposed <- propose_estimated_dates(i, augmented_data, observed_dates, group,
+                                      model_info, rng1, FALSE)
+  
+  augmented_data_proposed <- proposed$augmented_data
+  updated_dates <- proposed$updated
+  
+  accept_prob <- calc_accept_prob(updated_dates, augmented_data_proposed,
+                                  augmented_data, observed_dates, group,
+                                  prob_error, model_info, date_range)
+  
+  accept <- log(monty::monty_random_real(rng1)) < accept_prob
+  
+  if (accept) {
+    expect_equal(augmented_data_new, augmented_data_proposed)
+  } else {
+    expect_equal(augmented_data_new, augmented_data)
+  }
+  expect_equal(monty::monty_rng_state(rng), monty::monty_rng_state(rng1))
+  
+  ## group 4, update correct report (date 3)
+  ## no connected missing/erroneous dates so only date 3 to update
+  group <- 4
+  i <- 3
+  observed_dates <- c(10, 5, 30, NA, NA)
+  augmented_data <- list(estimated_dates = c(10.3, 15.4, 30.2, 40.1, NA),
+                         error_indicators = c(FALSE, FALSE, FALSE, NA, NA))
+  
+  rng <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
+  
+  augmented_data_new <- 
+    update_estimated_dates1(i, augmented_data, observed_dates, group,
+                            prob_error, model_info, date_range, control, rng)
+  
+  x <- monty::monty_random_real(rng1)
+  proposed <- propose_estimated_dates(i, augmented_data, observed_dates, group,
+                                      model_info, rng1, FALSE)
+  
+  augmented_data_proposed <- proposed$augmented_data
+  updated_dates <- proposed$updated
+  
+  accept_prob <- calc_accept_prob(updated_dates, augmented_data_proposed,
+                                  augmented_data, observed_dates, group,
+                                  prob_error, model_info, date_range)
+  accept <- log(monty::monty_random_real(rng1)) < accept_prob
+  
+  if (accept) {
+    expect_equal(augmented_data_new, augmented_data_proposed)
+  } else {
+    expect_equal(augmented_data_new, augmented_data)
+  }
+  expect_equal(monty::monty_rng_state(rng), monty::monty_rng_state(rng1))
+})
 
 test_that("updating estimated dates skipped correctly", {
   delay_map <- toy_model()$delay_map
@@ -148,6 +454,26 @@ test_that("updating error indicators skipped correctly", {
   
 })
 
+test_that("has_mixed_errors returns TRUE only when both TRUE and FALSE present", {
+  # Only non-errors
+  expect_false(has_mixed_errors(c(FALSE, FALSE)))
+  expect_false(has_mixed_errors(c(FALSE, FALSE, FALSE)))
+  # Only errors
+  expect_false(has_mixed_errors(c(TRUE, TRUE)))
+  # Only missing
+  expect_false(has_mixed_errors(c(NA, NA)))
+  # Non-errors and missing (no TRUE)
+  expect_false(has_mixed_errors(c(FALSE, NA)))
+  expect_false(has_mixed_errors(c(FALSE, FALSE, NA)))
+  # Errors and missing (no FALSE)
+  expect_false(has_mixed_errors(c(TRUE, NA)))
+  expect_false(has_mixed_errors(c(TRUE, TRUE, NA)))
+  # Mixed: both FALSE and TRUE present (NA irrelevant)
+  expect_true(has_mixed_errors(c(FALSE, TRUE)))
+  expect_true(has_mixed_errors(c(FALSE, TRUE, NA)))
+  expect_true(has_mixed_errors(c(TRUE, FALSE, FALSE)))
+  expect_true(has_mixed_errors(c(NA, FALSE, TRUE, NA)))
+})
 
 test_that("swap error indicators skipped correctly", {
   delay_map <- toy_model()$delay_map
@@ -220,94 +546,152 @@ test_that("estimated dates proposed correctly", {
   rng <- monty::monty_rng_create(seed = 1)
   rng1 <- monty::monty_rng_create(seed = 1)
   
-  ## group 2, propose new (correct) report date
+  ## group 2, propose new (correct) report date (date 3)
+  ## update date 1 (onset) using date 3
+  ## update date 4 using date 1
   group <- 2
-  to_update <- 3
+  i <- 3
   observed_dates <- c(NA, NA, 40, 68, NA)
   augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
                          error_indicators = c(NA, NA, FALSE, TRUE, NA))
-  augmented_data_new <- 
-    propose_estimated_dates(to_update, augmented_data, observed_dates, group,
-                            model_info, rng, FALSE)
+  proposed <- propose_estimated_dates(i, augmented_data, observed_dates, group,
+                                      model_info, rng, FALSE)
+  
+  proposed_error_indicators <- proposed$augmented_data$error_indicators
+  proposed_estimated_dates <- proposed$augmented_data$estimated_dates
+  proposed_updates <- proposed$updated
+  
   expect_equal(augmented_data$error_indicators,
-               augmented_data_new$error_indicators)
-  expect_equal(augmented_data$estimated_dates[-to_update],
-               augmented_data_new$estimated_dates[-to_update])
-  expect_equal(augmented_data_new$estimated_dates[to_update],
-               observed_dates[to_update] + monty::monty_random_real(rng1))
+               proposed_error_indicators)
+  expect_equal(augmented_data$estimated_dates[-proposed_updates],
+               proposed_estimated_dates[-proposed_updates])
+  expect_equal(proposed_estimated_dates[3],
+               observed_dates[3] + monty::monty_random_real(rng1))
+  expect_equal(proposed_updates, c(3, 1, 4))
   
-  
-  ## group 2, propose new (error) death date
+  ## group 2, propose new (error) death date (4)
+  ## updated death (4) used to re-estimate missing onset (1)
+  ## report (3) is connected to 1 but it is correct, so no update
   group <- 2
-  to_update <- 4
+  i <- 4
   observed_dates <- c(NA, NA, 40, 68, NA)
   augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
                          error_indicators = c(NA, NA, FALSE, TRUE, NA))
-  augmented_data_new <- 
-    propose_estimated_dates(to_update, augmented_data, observed_dates, group,
+  
+  rng <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
+  
+  proposed <- 
+    propose_estimated_dates(i, augmented_data, observed_dates, group,
                             model_info, rng, FALSE)
+  
+  proposed_error_indicators <- proposed$augmented_data$error_indicators
+  proposed_estimated_dates <- proposed$augmented_data$estimated_dates
+  proposed_updates <- proposed$updated
+  
   expect_equal(augmented_data$error_indicators,
-               augmented_data_new$error_indicators)
-  expect_equal(augmented_data$estimated_dates[-to_update],
-               augmented_data_new$estimated_dates[-to_update])
-  expect_equal(augmented_data_new$estimated_dates[to_update],
-               sample_from_delay(to_update, augmented_data_new$estimated_dates,
+               proposed_error_indicators)
+  expect_equal(augmented_data$estimated_dates[-proposed_updates],
+               proposed_estimated_dates[-proposed_updates])
+  expect_equal(proposed_estimated_dates[4],
+               sample_from_delay(4, augmented_data$estimated_dates,
+                                 augmented_data$error_indicators, group,
+                                 model_info, rng1))
+  expect_equal(proposed_updates, c(4, 1))
+  
+  
+  ## group 2, propose new (missing) onset date (1)
+  ## report (3) is correct so not updated
+  ## death (4) is error and is updated
+  group <- 2
+  i <- 1
+  observed_dates <- c(NA, NA, 40, 68, NA)
+  augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
+                         error_indicators = c(NA, NA, FALSE, TRUE, NA))
+  
+  rng <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
+  
+  proposed <- 
+    propose_estimated_dates(i, augmented_data, observed_dates, group,
+                            model_info, rng, FALSE)
+  
+  proposed_error_indicators <- proposed$augmented_data$error_indicators
+  proposed_estimated_dates <- proposed$augmented_data$estimated_dates
+  proposed_updates <- proposed$updated
+  
+  expect_equal(augmented_data$error_indicators,
+               proposed_error_indicators)
+  expect_equal(augmented_data$estimated_dates[-proposed_updates],
+               proposed_estimated_dates[-proposed_updates])
+  expect_equal(proposed_estimated_dates[1],
+               sample_from_delay(1, proposed_estimated_dates,
+                                 proposed_error_indicators,
+                                 group, model_info, rng1))
+  expect_equal(proposed_estimated_dates[4],
+               sample_from_delay(4, proposed_estimated_dates,
+                                 proposed_error_indicators,
                                  group, model_info, rng1))
   
   
-  ## group 2, propose new (missing) onset date
+  ## group 2, propose new report date (3), going from correct to error
+  ## update missing onset date (1) then update erroneous death date (4)
   group <- 2
-  to_update <- 1
+  i <- 3
   observed_dates <- c(NA, NA, 40, 68, NA)
   augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
                          error_indicators = c(NA, NA, FALSE, TRUE, NA))
-  augmented_data_new <- 
-    propose_estimated_dates(to_update, augmented_data, observed_dates, group,
-                            model_info, rng, FALSE)
-  expect_equal(augmented_data$error_indicators,
-               augmented_data_new$error_indicators)
-  expect_equal(augmented_data$estimated_dates[-to_update],
-               augmented_data_new$estimated_dates[-to_update])
-  expect_equal(augmented_data_new$estimated_dates[to_update],
-               sample_from_delay(to_update, augmented_data_new$estimated_dates,
+  
+  rng <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
+  
+  proposed <- 
+    propose_estimated_dates(i, augmented_data, observed_dates, group,
+                            model_info, rng, update_errors = TRUE)
+  
+  proposed_error_indicators <- proposed$augmented_data$error_indicators
+  proposed_estimated_dates <- proposed$augmented_data$estimated_dates
+  proposed_updates <- proposed$updated
+  
+  expect_equal(augmented_data$error_indicators[-proposed_updates],
+               proposed_error_indicators[-proposed_updates])
+  expect_equal(proposed_updates, c(3, 1, 4))
+  expect_equal(proposed_error_indicators, c(NA, NA, TRUE, TRUE, NA))
+  expect_equal(augmented_data$estimated_dates[-proposed_updates],
+               proposed_estimated_dates[-proposed_updates])
+  expect_equal(proposed_estimated_dates[3],
+               sample_from_delay(3, augmented_data$estimated_dates,
+                                 augmented_data$error_indicators,
                                  group, model_info, rng1))
   
-  
-  ## group 2, propose new report date, going from correct to error
+  ## group 2, propose new death date (4), going from error to correct
+  ## then update missing onset date (1)
+  ## no need to update other date as it is correct
   group <- 2
-  to_update <- 3
+  i <- 4
   observed_dates <- c(NA, NA, 40, 68, NA)
   augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
                          error_indicators = c(NA, NA, FALSE, TRUE, NA))
-  augmented_data_new <- 
-    propose_estimated_dates(to_update, augmented_data, observed_dates, group,
-                            model_info, rng, TRUE)
-  expect_equal(augmented_data$error_indicators[-to_update],
-               augmented_data_new$error_indicators[-to_update])
-  expect_equal(augmented_data$error_indicators[to_update], FALSE)
-  expect_equal(augmented_data$estimated_dates[-to_update],
-               augmented_data_new$estimated_dates[-to_update])
-  expect_equal(augmented_data_new$estimated_dates[to_update],
-               sample_from_delay(to_update, augmented_data_new$estimated_dates,
-                                 group, model_info, rng1))
   
+  rng <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
   
-  ## group 2, propose new death date, going from error to correct
-  group <- 2
-  to_update <- 4
-  observed_dates <- c(NA, NA, 40, 68, NA)
-  augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
-                         error_indicators = c(NA, NA, FALSE, TRUE, NA))
-  augmented_data_new <- 
-    propose_estimated_dates(to_update, augmented_data, observed_dates, group,
-                            model_info, rng, TRUE)
-  expect_equal(augmented_data$error_indicators[-to_update],
-               augmented_data_new$error_indicators[-to_update])
-  expect_equal(augmented_data$error_indicators[to_update], TRUE)
-  expect_equal(augmented_data$estimated_dates[-to_update],
-               augmented_data_new$estimated_dates[-to_update])
-  expect_equal(augmented_data_new$estimated_dates[to_update],
-               observed_dates[to_update] + monty::monty_random_real(rng1))
+  proposed <- 
+    propose_estimated_dates(i, augmented_data, observed_dates, group,
+                            model_info, rng, update_errors = TRUE)
+  
+  proposed_error_indicators <- proposed$augmented_data$error_indicators
+  proposed_estimated_dates <- proposed$augmented_data$estimated_dates
+  proposed_updates <- proposed$updated
+  
+  expect_equal(augmented_data$error_indicators[-proposed_updates],
+               proposed_error_indicators[-proposed_updates])
+  expect_equal(proposed_updates, c(4, 1))
+  expect_equal(proposed_error_indicators[proposed_updates], c(FALSE, NA))
+  expect_equal(augmented_data$estimated_dates[-proposed_updates],
+               proposed_estimated_dates[-proposed_updates])
+  expect_equal(proposed_estimated_dates[4],
+               observed_dates[4] + monty::monty_random_real(rng1))
   
   
   ## group 2, propose all dates, swapping errors
@@ -316,20 +700,32 @@ test_that("estimated dates proposed correctly", {
   observed_dates <- c(NA, NA, 40, 68, NA)
   augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
                          error_indicators = c(NA, NA, FALSE, TRUE, NA))
-  augmented_data_new <- 
+  
+  rng <- monty::monty_rng_create(seed = 1)
+  rng1 <- monty::monty_rng_create(seed = 1)
+  
+  proposed <- 
     propose_estimated_dates(to_update, augmented_data, observed_dates, group,
-                            model_info, rng, TRUE)
-  expect_equal(augmented_data_new$error_indicators, 
-               c(NA, NA, TRUE, FALSE, NA))
+                            model_info, rng, update_errors = TRUE)
+  
+  proposed_error_indicators <- proposed$augmented_data$error_indicators
+  proposed_estimated_dates <- proposed$augmented_data$estimated_dates
+  proposed_updates <- proposed$updated
+  
+  expect_equal(proposed_error_indicators, c(NA, NA, TRUE, FALSE, NA))
+  expect_equal(proposed_updates, c(4, 1, 3))
+  
   estimated_dates <- rep(NA, 5)
   ## date 4 will be sampled based on observed date
   estimated_dates[4] <- observed_dates[4] + monty::monty_random_real(rng1)
   ## will then sample date 1 (connected to date 4) and then date 3
   estimated_dates[1] <- 
-    sample_from_delay(1, estimated_dates, group, model_info, rng1)
+    sample_from_delay(1, estimated_dates, c(NA, NA, TRUE, FALSE, NA),
+                      group, model_info, rng1)
   estimated_dates[3] <- 
-    sample_from_delay(3, estimated_dates, group, model_info, rng1)
-  expect_equal(augmented_data_new$estimated_dates, estimated_dates)
+    sample_from_delay(3, estimated_dates, c(NA, NA, TRUE, FALSE, NA),
+                      group, model_info, rng1)
+  expect_equal(proposed_estimated_dates, estimated_dates)
   
 })
 
@@ -369,30 +765,26 @@ test_that("proposal density calculated correctly", {
     calc_proposal_density(updated, augmented_data, group, model_info), d)
   
   ## group 2, updated missing onset date 
-  ## based on delay 1 (gamma), onset (date 1) to report (date 3)
-  ## and delay 2 (gamma), onset (date 1) to death (date 4)
-  ## the two delays are equally likely to be used
+  ## report (date 3) is correct so delay 1 prioritised over delay 2
   updated <- 1
-  d <- log(sum(dgamma(augmented_data$estimated_dates[c(3, 4)] - 
-                        augmented_data$estimated_dates[1],
-                      shape = params[1, c(1, 2)], 
-                      rate = params[2, c(1, 2)]))) - log(2)
+  d <- dgamma(augmented_data$estimated_dates[3] - augmented_data$estimated_dates[1],
+              shape = params[1, 1], rate = params[2, 1], log = TRUE)
   expect_equal(
     calc_proposal_density(updated, augmented_data, group, model_info), d)
   
   ## group 2, updated all dates
-  ## report (date 3) is correct so has no impact for proposing this
-  ## then onset is proposed based on delay 1 (gamma), 
-  ##               onset (date 1) to report (date 3)
-  ## then death is proposed based on delay 2 (gamma),
-  ##               onset (date 1) to death (date 4)
+  ## report (date 3) is correct, no density contribution
+  ## onset (date 1): only delay 1 available at time of sampling (death not yet
+  ##   available); report (3) is correct so no prioritisation change needed
+  ## death (date 4): only delay 2 available (onset now available); onset (1) is
+  ##   missing so no prioritisation
   updated <- c(1, 3, 4)
   d <- sum(dgamma(augmented_data$estimated_dates[c(3, 4)] - 
                     augmented_data$estimated_dates[1],
                   shape = params[1, c(1, 2)], rate = params[2, c(1, 2)],
                   log = TRUE))
   expect_equal(
-    calc_proposal_density(updated, augmented_data, group, model_info), d)
+    calc_proposal_density(updated, augmented_data, group, model_info, is_batch = TRUE), d)
   
   
   # group 4, 3 dates
@@ -413,19 +805,34 @@ test_that("proposal density calculated correctly", {
     calc_proposal_density(updated, augmented_data, group, model_info), 0)
   
   ## group 4, updated error hospitalisation date 
-  ## based on delay 5 (log-normal), onset (date 1) to hospitalisation (date 2)
-  ## and delay 6 (log-normal), hospitalisation (date 2) to death (date 4)
-  ## the two delays are equally likely to be used
+  ## onset (date 1) is correct and death (date 4) is missing so only
+  ## delay 5 (onset to hosp) is prioritised
   updated <- 2
-  d <- log(sum(dlnorm(augmented_data$estimated_dates[c(2, 4)] - 
-                        augmented_data$estimated_dates[c(1, 2)],
-                      meanlog = params[1, c(5, 6)], 
-                      sdlog = params[2, c(5, 6)]))) - log(2)
+  d <- dlnorm(augmented_data$estimated_dates[2] - augmented_data$estimated_dates[1],
+              meanlog = params[1, 5], sdlog = params[2, 5], log = TRUE)
   expect_equal(
     calc_proposal_density(updated, augmented_data, group, model_info), d)
   
-  ## group 4, updated missing death date 
+  ## group 4, updated error hospitalisation date with both connected dates correct
+  ## onset (date 1) and death (date 4) both correct so delays 5 and 6 both
+  ## prioritised -- uniform mixture over the two correct delays
+  augmented_data_both_correct <- list(
+    estimated_dates = c(10.3, 15.4, 30.2, 40.1, NA),
+    error_indicators = c(FALSE, TRUE, FALSE, FALSE, NA))
+  updated <- 2
+  d <- log(sum(dlnorm(augmented_data_both_correct$estimated_dates[c(2, 4)] - 
+                        augmented_data_both_correct$estimated_dates[c(1, 2)],
+                      meanlog = params[1, c(5, 6)], 
+                      sdlog = params[2, c(5, 6)]))) - log(2)
+  expect_equal(
+    calc_proposal_density(updated, augmented_data_both_correct, group,
+                          model_info), d)
+  
+  ## group 4, updated missing death date
+  ## hosp (date 2) is erroneous so no prioritisation
   ## based on delay 6 (log-normal), hospitalisation (date 2) to death (date 4)
+  augmented_data <- list(estimated_dates = c(10.3, 15.4, 30.2, 40.1, NA),
+                         error_indicators = c(FALSE, TRUE, FALSE, NA, NA))
   updated <- 4
   d <- dlnorm(augmented_data$estimated_dates[4] - 
                 augmented_data$estimated_dates[2],
@@ -434,18 +841,18 @@ test_that("proposal density calculated correctly", {
     calc_proposal_density(updated, augmented_data, group, model_info), d)
   
   ## group 4, updated all dates
-  ## onset (date 1) and report (date 3) correct so no impact for proposing
-  ## then hospitalisation is proposed based on delay 5, onset (date 1) to
-  ##    hospitalisation (date 2)
-  ## then death is proposed based on delay 6 (log-normal), hospitalisation
-  ##    (date 2) to death (date 4)
+  ## onset (date 1) and report (date 3) correct, no density contribution
+  ## hosp (date 2): only delay 5 available at time of sampling (death not yet
+  ##   available); onset (1) correct so prioritised, same result
+  ## death (date 4): only delay 6 available (hosp now available); hosp (2) is
+  ##   erroneous so no prioritisation
   updated <- c(1, 2, 3, 4)
   d <- sum(dlnorm(augmented_data$estimated_dates[c(2, 4)] - 
                     augmented_data$estimated_dates[c(1, 2)],
                   meanlog = params[1, c(5, 6)], sdlog = params[2, c(5, 6)],
                   log = TRUE))
   expect_equal(
-    calc_proposal_density(updated, augmented_data, group, model_info), d)
+    calc_proposal_density(updated, augmented_data, group, model_info, is_batch = TRUE), d)
 })
 
 
@@ -462,7 +869,8 @@ test_that("acceptance probability calculated correctly", {
   date_range <- c(0, 101)
   
   ## separate function for calculating acceptance probability
-  calc_accept <- function(updated, augmented_data_new, augmented_data, group) {
+  calc_accept <- function(updated, augmented_data_new, augmented_data, group,
+                          is_batch = FALSE) {
     ll_delays_current <- 
       datefixer_log_likelihood_delays1(augmented_data$estimated_dates,
                                        model_info$delay_mean, 
@@ -494,9 +902,9 @@ test_that("acceptance probability calculated correctly", {
     ratio_post <- ratio_ll_delays + ratio_ll_errors
     
     prop_current <- 
-      calc_proposal_density(updated, augmented_data, group, model_info)
+      calc_proposal_density(updated, augmented_data, group, model_info, is_batch)
     prop_new <- 
-      calc_proposal_density(updated, augmented_data_new, group, model_info)
+      calc_proposal_density(updated, augmented_data_new, group, model_info, is_batch)
     ratio_prop <- prop_current - prop_new
     
     ratio_post + ratio_prop
@@ -577,8 +985,9 @@ test_that("acceptance probability calculated correctly", {
   expect_equal(
     calc_accept_prob(updated, augmented_data_new, augmented_data,
                      observed_dates, group, prob_error, model_info,
-                     date_range),
-    calc_accept(updated, augmented_data_new, augmented_data, group))
+                     date_range, is_batch = TRUE),
+    calc_accept(updated, augmented_data_new, augmented_data, group,
+                is_batch = TRUE))
   
   
   ## group 4
@@ -594,6 +1003,6 @@ test_that("acceptance probability calculated correctly", {
   expect_equal(
     calc_accept_prob(updated, augmented_data_new, augmented_data,
                      observed_dates, group, prob_error, model_info,
-                     date_range),
-    calc_accept(updated, augmented_data_new, augmented_data, group))
+                     date_range, is_batch = TRUE),
+    calc_accept(updated, augmented_data_new, augmented_data, group, is_batch = TRUE))
 })

--- a/tests/testthat/test-mcmc-augmented-data-update.R
+++ b/tests/testthat/test-mcmc-augmented-data-update.R
@@ -238,6 +238,47 @@ test_that("updating error indicator cascades to connected dates", {
   expect_equal(monty::monty_rng_state(rng), monty::monty_rng_state(rng1))
 })
 
+test_that("calc_accept_prob correctly calculates a positive ratio for a better fit", {
+  delay_map <- toy_model()$delay_map
+  dates <- c("onset", "hospitalisation", "report", "death", "discharge")
+  model_info <- make_model_info(delay_map, dates)
+  
+  # Set tight distributions: Mean = 10, CV = 0.1
+  model_info$delay_mean <- rep(10, 6)
+  model_info$delay_cv <- rep(0.1, 6)
+  prob_error <- 0.05
+  date_range <- c(0, 1000)
+  group <- 2 # community-dead (onset -> report, onset -> death)
+  
+  # Current: delay from onset -> report is only 2 days, model wants 10
+  augmented_data <- list(
+    estimated_dates = c(100.0, NA, 102.0, 110.0, NA),
+    error_indicators = c(NA, NA, FALSE, FALSE, NA)
+  )
+  
+  # Proposed: delay is exactly 10 days
+  augmented_data_new <- list(
+    estimated_dates = c(100.0, NA, 110.0, 110.0, NA),
+    error_indicators = c(NA, NA, FALSE, FALSE, NA)
+  )
+  
+  updated <- 3
+
+  log_accept_ratio <- calc_accept_prob(
+    updated, augmented_data_new, augmented_data,
+    observed_dates = c(NA, NA, 102, 110, NA), # observed matches current exactly
+    group, prob_error, model_info, date_range, is_batch = FALSE
+  )
+  
+  # check that the ratio is positive (new state is much better than old state)
+  expect_gt(log_accept_ratio, 0)
+  
+  # check that very high ratio leads to acceptance
+  # exp(log_accept_ratio) will be > 1, so any probability draw will be < than it
+  expect_true(exp(log_accept_ratio) >= 1)
+})
+
+
 test_that("updating estimated date cascades to connected missing/erroneous dates", {
   delay_map <- toy_model()$delay_map
   dates <- c("onset", "hospitalisation", "report", "death", "discharge")


### PR DESCRIPTION
- Add new "cascading" resampling, so that when a single date is updated the connected erroneous/missing dates are also updated
- Distinguishes between "batch" updates where all dates are cleared and resampled using correct "anchor" dates, and the above "cascade" updates where only one date is cleared at a time