### PR TITLE
Find nearest cascade anchor and use cascade sampling for update dates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chronofix
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.4
+Version: 0.0.5
 Authors@R: 
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
 Description: chronofix is an R package for Bayesian estimation of event dates

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -84,7 +84,7 @@ update_estimated_dates1 <- function(i, augmented_data, observed_dates, group,
   
   augmented_data_new <- 
     propose_estimated_dates(sampling_order, augmented_data, observed_dates,
-                            group, delay_pars, model_info, rng)
+                            group, delay_pars, model_info, date_range, rng)
   
   accept_prob <-
     calc_accept_prob(sampling_order, sampling_order_reverse,
@@ -150,8 +150,8 @@ update_error_indicators1 <- function(i, augmented_data, observed_dates, group,
   }
   
   augmented_data_new <- 
-    propose_estimated_dates(sampling_order, augmented_data_new,
-                            observed_dates, group, delay_pars, model_info, rng)
+    propose_estimated_dates(sampling_order, augmented_data_new, observed_dates, 
+                            group, delay_pars, model_info, date_range, rng)
   
   accept_prob <-
     calc_accept_prob(sampling_order, sampling_order_reverse,
@@ -169,8 +169,7 @@ update_error_indicators1 <- function(i, augmented_data, observed_dates, group,
 
 # Sample new date using randomly selected delay
 sample_from_delay <- function(i, augmented_data, group, delay_pars, model_info,
-                              rng) {
-  
+                              date_range, rng) {
   is_date_in_delay <- model_info$is_date_in_delay[i, , group]
   
   ## Which delays involve this date
@@ -181,38 +180,45 @@ sample_from_delay <- function(i, augmented_data, group, delay_pars, model_info,
   
   ## Filter to only delays where the other date is available (needed for swap)
   is_available_date <- !is.na(augmented_data$estimated_dates[other_date_idx])
-  valid_delays <- which_delays[is_available_date]
-  other_date_idx <- other_date_idx[is_available_date]
-  
-  ## If it is involved in several delays, randomly select one
-  delay_idx <- if (length(valid_delays) == 1) 1 else 
-    ceiling(length(valid_delays) * monty::monty_random_real(rng))
-  selected_delay <- valid_delays[delay_idx]
-  
-  ## Find the other date in this date pair
-  other_date <- augmented_data$estimated_dates[other_date_idx[delay_idx]]
-  
-  ## Is date i the 'from' or 'to' in this delay
-  is_from <- (i == model_info$delay_from[selected_delay])
-  
-  if (is_from) {
-    ## proposed date = other_date - delay
-    ## so delay = other_date - proposed_date
-    sign <- -1
+  if (!any(is_available_date)) {
+    ## not possible to sample from a delay so sample a random date
+    d <- as.numeric(date_range)
+    proposed_date <- monty::monty_random_uniform(d[1L], d[2L], rng)
   } else {
-    ## proposed date = other_date + delay  
-    ## so delay = proposed_date - other_date
-    sign <- 1
+    valid_delays <- which_delays[is_available_date]
+    other_date_idx <- other_date_idx[is_available_date]
+    
+    ## If it is involved in several delays, randomly select one
+    delay_idx <- if (length(valid_delays) == 1) 1 else 
+      ceiling(length(valid_delays) * monty::monty_random_real(rng))
+    selected_delay <- valid_delays[delay_idx]
+    
+    ## Find the other date in this date pair
+    other_date <- augmented_data$estimated_dates[other_date_idx[delay_idx]]
+    
+    ## Is date i the 'from' or 'to' in this delay
+    is_from <- (i == model_info$delay_from[selected_delay])
+    
+    if (is_from) {
+      ## proposed date = other_date - delay
+      ## so delay = other_date - proposed_date
+      sign <- -1
+    } else {
+      ## proposed date = other_date + delay  
+      ## so delay = proposed_date - other_date
+      sign <- 1
+    }
+    
+    ## Sample a delay from the marginal posterior
+    pars <- delay_pars[[selected_delay]]
+    distribution <- model_info$delay_distribution[selected_delay]
+    
+    sampled_delay <- sample_from_delay1(pars, distribution, rng)
+    
+    ## Calculate proposed date based on the sampled delay
+    proposed_date <- other_date + sign * sampled_delay
   }
   
-  ## Sample a delay from the marginal posterior
-  pars <- delay_pars[[selected_delay]]
-  distribution <- model_info$delay_distribution[selected_delay]
-  
-  sampled_delay <- sample_from_delay1(pars, distribution, rng)
-  
-  ## Calculate proposed date based on the sampled delay
-  proposed_date <- other_date + sign * sampled_delay
   
   proposed_date
   
@@ -236,7 +242,7 @@ sample_from_delay1 <- function(pars, distribution, rng) {
 # propose new estimated dates for date indices in to_update
 propose_estimated_dates <- function(sampling_order, augmented_data,
                                     observed_dates, group, delay_pars,
-                                    model_info, rng) {
+                                    model_info, date_range, rng) {
   
   augmented_data$estimated_dates[sampling_order] <- NA
   
@@ -246,7 +252,8 @@ propose_estimated_dates <- function(sampling_order, augmented_data,
         observed_dates[i] + monty::monty_random_real(rng)
     } else {
       augmented_data$estimated_dates[i] <-
-        sample_from_delay(i, augmented_data, group, delay_pars, model_info, rng)
+        sample_from_delay(i, augmented_data, group, delay_pars, 
+                          model_info, date_range, rng)
     }
   }
   
@@ -322,10 +329,11 @@ calc_accept_prob <- function(sampling_order, sampling_order_reverse,
     return(-Inf)
   }
   
-  prop_current <- calc_proposal_density(sampling_order_reverse, augmented_data,
-                                        group, delay_pars, model_info)
+  prop_current <- 
+    calc_proposal_density(sampling_order_reverse, augmented_data, group, 
+                          delay_pars, model_info, date_range)
   prop_new <- calc_proposal_density(sampling_order, augmented_data_new,
-                                    group, delay_pars, model_info)
+                                    group, delay_pars, model_info, date_range)
   ratio_prop <- prop_current - prop_new
   
   ratio_post + ratio_prop
@@ -333,8 +341,7 @@ calc_accept_prob <- function(sampling_order, sampling_order_reverse,
 
 
 calc_proposal_density <- function(sampling_order, augmented_data,
-                                  group, delay_pars, model_info) {
-  
+                                  group, delay_pars, model_info, date_range) {
   is_date_in_delay <- model_info$is_date_in_delay[, , group]
   dim(is_date_in_delay) <- dim(model_info$is_date_in_delay)[1:2]
   is_date_in_group <- model_info$is_date_in_group[, group]
@@ -359,29 +366,34 @@ calc_proposal_density <- function(sampling_order, augmented_data,
       ## which dates were available for sampling
       connected_dates <- available_dates[is_date_connected[i, available_dates]]
       
-      is_delay_available <- 
-        colSums(is_date_in_delay[connected_dates, , drop = FALSE]) > 0
-      ## which delays could be sampled from
-      can_sample_from_delay <- is_date_in_delay[i, ] & 
-        is_delay_available
-      
-      ## error or missing - proposal is based on delay(s)
-      delay_pars_sample <- delay_pars[can_sample_from_delay]
-      delay_distribution <- model_info$delay_distribution[can_sample_from_delay]
-      delay_from <- model_info$delay_from[can_sample_from_delay]
-      delay_to <- model_info$delay_to[can_sample_from_delay]
-      delay_values <- augmented_data$estimated_dates[delay_to] - 
-        augmented_data$estimated_dates[delay_from]
-      
-      if (sum(can_sample_from_delay) == 1) {
-        ## single delay involving date i
-        d[j] <- log_density_delay(delay_values, delay_pars_sample[[1]],
-                                  delay_distribution)
+      if (length(connected_dates) == 0) {
+        ## no connected date available so just sampled from date range
+        d[j] <- -log(date_range[2L] - date_range[1L])
       } else {
-        ## multiple delays involving date i, so delay selected at random
-        d[j] <- log(sum(exp(mapply(log_density_delay, delay_values, 
-                                   delay_pars_sample, delay_distribution)))) - 
-                      log(sum(can_sample_from_delay))
+        is_delay_available <- 
+          colSums(is_date_in_delay[connected_dates, , drop = FALSE]) > 0
+        ## which delays could be sampled from
+        can_sample_from_delay <- is_date_in_delay[i, ] & 
+          is_delay_available
+        
+        ## error or missing - proposal is based on delay(s)
+        delay_pars_sample <- delay_pars[can_sample_from_delay]
+        delay_distribution <- model_info$delay_distribution[can_sample_from_delay]
+        delay_from <- model_info$delay_from[can_sample_from_delay]
+        delay_to <- model_info$delay_to[can_sample_from_delay]
+        delay_values <- augmented_data$estimated_dates[delay_to] - 
+          augmented_data$estimated_dates[delay_from]
+        
+        if (sum(can_sample_from_delay) == 1) {
+          ## single delay involving date i
+          d[j] <- log_density_delay(delay_values, delay_pars_sample[[1]],
+                                    delay_distribution)
+        } else {
+          ## multiple delays involving date i, so delay selected at random
+          d[j] <- log(sum(exp(mapply(log_density_delay, delay_values, 
+                                     delay_pars_sample, delay_distribution)))) - 
+            log(sum(can_sample_from_delay))
+        }
       }
       
     }
@@ -429,8 +441,8 @@ swap_error_indicators <- function(augmented_data, observed_dates, group,
 
   # systematically sample new errors and missing dates based on new non-errors
   augmented_data_new <- 
-    propose_estimated_dates(sampling_order, augmented_data_new,
-                            observed_dates, group, delay_pars, model_info, rng)
+    propose_estimated_dates(sampling_order, augmented_data_new, observed_dates, 
+                            group, delay_pars, model_info, date_range, rng)
 
   accept_prob <-
     calc_accept_prob(sampling_order, sampling_order_reverse,
@@ -492,9 +504,6 @@ calc_cascade_sampling_order <- function(i, event_order,
   
   ## Check if there are any correct dates, if not then we do not cascade
   is_possible_anchor <- vlapply(error_indicators[event_order], isFALSE)
-  if (!any(is_possible_anchor)) {
-    return(i)
-  }
   
   if (is_possible_anchor[event_order == i]) {
     ## Date i is correct so use itself as an anchor
@@ -509,8 +518,8 @@ calc_cascade_sampling_order <- function(i, event_order,
       shortest_path_lengths <- 
         vnapply(shortest_paths[[i]][possible_anchors], length)
       if (all(shortest_path_lengths == 0)) {
-        ## No path to an anchor
-        return(i)
+        ## No path to an anchor so cascade from i
+        sampling_order <- i
       } else {
         possible_anchors <- possible_anchors[shortest_path_lengths > 0]
         shortest_path_lengths <- 

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -71,10 +71,7 @@ update_estimated_dates1 <- function(i, augmented_data, observed_dates, group,
     return(augmented_data)
   }
   
-  cascade <- control$cascade_sampling &&
-    !isFALSE(augmented_data$error_indicators[i])
-  
-  if (cascade) {
+  if (control$cascade_sampling) {
     sampling_order <- 
       calc_cascade_sampling_order(i, model_info$event_order[[group]],
                                   augmented_data$error_indicators,

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -129,11 +129,13 @@ update_error_indicators1 <- function(i, augmented_data, observed_dates, group,
     sampling_order <- 
       calc_cascade_sampling_order(i, model_info$event_order[[group]],
                                   augmented_data_new$error_indicators,
-                                  model_info$is_date_connected[, , group])
+                                  model_info$is_date_connected[, , group],
+                                  model_info$shortest_paths[[group]])
     sampling_order_reverse <- 
       calc_cascade_sampling_order(i, model_info$event_order[[group]],
                                   augmented_data$error_indicators,
-                                  model_info$is_date_connected[, , group])
+                                  model_info$is_date_connected[, , group],
+                                  model_info$shortest_paths[[group]])
   } else {
     sampling_order <- i
     sampling_order_reverse <- i
@@ -492,23 +494,43 @@ calc_batch_sampling_order <- function(to_resample, error_indicators,
 
 
 calc_cascade_sampling_order <- function(i, event_order,
-                                        error_indicators, is_date_connected) {
+                                        error_indicators, is_date_connected,
+                                        shortest_paths) {
   
-  ## If date i is missing or erroneous, check if there is a connected date
-  ## that is correct to anchor against
-  if (!isFALSE(error_indicators[i])) {
-    has_anchor <- any(is_date_connected[event_order, i] & 
-                        vlapply(error_indicators[event_order], isFALSE))
-    if (!has_anchor) {
-      return(i)
+  ## Check if there are any correct dates, if not then we do not cascade
+  is_possible_anchor <- vlapply(error_indicators[event_order], isFALSE)
+  if (!any(is_possible_anchor)) {
+    return(i)
+  }
+  
+  if (is_possible_anchor[event_order == i]) {
+    ## Date i is correct so use itself as an anchor
+    sampling_order <- i
+  } else {
+    has_anchor <- any(is_date_connected[i, event_order] & is_possible_anchor)
+    if (has_anchor) {
+      ## Date is connected to an anchor
+      sampling_order <- i
+    } else {
+      possible_anchors <- event_order[is_possible_anchor]
+      shortest_path_lengths <- 
+        vnapply(shortest_paths[[i]][possible_anchors], length)
+      if (all(shortest_path_lengths == 0)) {
+        ## No path to an anchor
+        return(i)
+      } else {
+        possible_anchors <- possible_anchors[shortest_path_lengths > 0]
+        shortest_path_lengths <- 
+          shortest_path_lengths[shortest_path_lengths > 0]
+        anchor <- possible_anchors[which.min(shortest_path_lengths)]
+        sampling_order <- rev(shortest_paths[[i]][[anchor]])[-1L]
+      }
     }
   }
   
-  sampling_order <- i
-  
   ## cascade_candidates are dates not already in sampling_order that are
   ## missing or erroneous
-  cascade_candidates <- event_order[event_order != i]
+  cascade_candidates <- event_order[!(event_order %in% sampling_order)]
   is_cascade_candidate <- 
     !vlapply(error_indicators[cascade_candidates], isFALSE)
   cascade_candidates <- cascade_candidates[is_cascade_candidate]

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -187,15 +187,6 @@ sample_from_delay <- function(i, augmented_data, group, delay_pars, model_info,
   valid_delays <- which_delays[is_available_date]
   other_date_idx <- other_date_idx[is_available_date]
   
-  if (length(valid_delays) > 1) {
-    is_correct <- 
-      vlapply(augmented_data$error_indicators[other_date_idx], isFALSE)
-    if (any(is_correct)) {
-      valid_delays <- valid_delays[is_correct]
-      other_date_idx <- other_date_idx[is_correct]
-    } 
-  }
-  
   ## If it is involved in several delays, randomly select one
   delay_idx <- if (length(valid_delays) == 1) 1 else 
     ceiling(length(valid_delays) * monty::monty_random_real(rng))
@@ -370,13 +361,7 @@ calc_proposal_density <- function(sampling_order, augmented_data,
     if (!isFALSE(augmented_data$error_indicators[i])) {
       ## which dates were available for sampling
       connected_dates <- available_dates[is_date_connected[i, available_dates]]
-      if (length(connected_dates) > 1) {
-        is_correct <- 
-          vlapply(augmented_data$error_indicators[connected_dates], isFALSE)
-        if (sum(is_correct) > 0) {
-          connected_dates <- connected_dates[is_correct]
-        }
-      }
+      
       is_delay_available <- 
         colSums(is_date_in_delay[connected_dates, , drop = FALSE]) > 0
       ## which delays could be sampled from

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -78,7 +78,8 @@ update_estimated_dates1 <- function(i, augmented_data, observed_dates, group,
     sampling_order <- 
       calc_cascade_sampling_order(i, model_info$event_order[[group]],
                                   augmented_data$error_indicators,
-                                  model_info$is_date_connected[, , group])
+                                  model_info$is_date_connected[, , group],
+                                  model_info$shortest_paths[[group]])
   } else {
     sampling_order <- i
   }

--- a/R/mcmc-augmented-data-update.R
+++ b/R/mcmc-augmented-data-update.R
@@ -71,8 +71,18 @@ update_estimated_dates1 <- function(i, augmented_data, observed_dates, group,
     return(augmented_data)
   }
   
-  sampling_order <- i
-  sampling_order_reverse <- i
+  cascade <- control$cascade_sampling &&
+    !isFALSE(augmented_data$error_indicators[i])
+  
+  if (cascade) {
+    sampling_order <- 
+      calc_cascade_sampling_order(i, model_info$event_order[[group]],
+                                  augmented_data$error_indicators,
+                                  model_info$is_date_connected[, , group])
+  } else {
+    sampling_order <- i
+  }
+  sampling_order_reverse <- sampling_order
   
   augmented_data_new <- 
     propose_estimated_dates(sampling_order, augmented_data, observed_dates,

--- a/R/model.R
+++ b/R/model.R
@@ -245,6 +245,34 @@ make_model_info <- function(delay_map, dates) {
   }
   event_order <- lapply(seq_along(g), calc_event_order)
   
+  calc_shortest_paths <- function(group) {
+    # identify relevant delays and event dates for a group
+    dates_from <- delay_from[is_delay_in_group[, group]]
+    dates_to <- delay_to[is_delay_in_group[, group]]
+    
+    relevant_dates <- unique(c(dates_from, dates_to))
+    delay_df <- data.frame(from = dates_from, to = dates_to)
+    
+    event_graph <- igraph::graph_from_data_frame(delay_df,
+                                                 directed = FALSE,
+                                                 vertices = relevant_dates)
+    
+    paths <- rep(list(NULL), length(dates))
+    for (i in relevant_dates) {
+      paths_i <- rep(list(NULL), length(dates))
+      for (j in relevant_dates[relevant_dates != i]) {
+        paths_i[[j]] <-
+          suppressWarnings(
+            as.integer(igraph::shortest_paths(event_graph, 
+                                              as.character(i), 
+                                              as.character(j))$vpath[[1]]))
+      }
+      paths[[i]] <- paths_i
+    }
+    paths
+  }
+  shortest_paths <- lapply(seq_along(g), calc_shortest_paths)
+  
   list(delay_from = delay_from,
        delay_to = delay_to,
        delay_distribution = delay_distribution,
@@ -253,6 +281,7 @@ make_model_info <- function(delay_map, dates) {
        is_date_in_group = is_date_in_group,
        is_date_connected = is_date_connected,
        event_order = event_order,
+       shortest_paths = shortest_paths,
        groups = g)  
 }
 

--- a/R/model.R
+++ b/R/model.R
@@ -261,11 +261,11 @@ make_model_info <- function(delay_map, dates) {
     for (i in relevant_dates) {
       paths_i <- rep(list(NULL), length(dates))
       for (j in relevant_dates[relevant_dates != i]) {
-        paths_i[[j]] <-
-          suppressWarnings(
-            as.integer(igraph::shortest_paths(event_graph, 
-                                              as.character(i), 
-                                              as.character(j))$vpath[[1]]))
+        p <- suppressWarnings(
+          igraph::shortest_paths(event_graph, 
+                                 as.character(i), 
+                                 as.character(j))$vpath[[1]])
+        paths_i[[j]] <- relevant_dates[as.integer(p)]
       }
       paths[[i]] <- paths_i
     }

--- a/R/util.R
+++ b/R/util.R
@@ -33,3 +33,8 @@ squote <- function(x) {
 vlapply <- function(...) {
   vapply(..., FUN.VALUE = TRUE)
 }
+
+
+vnapply <- function(...) {
+  vapply(..., FUN.VALUE = 1)
+}

--- a/tests/testthat/helper-chronofix.R
+++ b/tests/testthat/helper-chronofix.R
@@ -73,6 +73,7 @@ toy_model <- function(named_groups = TRUE, control = chronofix_mcmc_control(),
   
   list(model = model,
        delay_map = params$delay_map,
-       data = sim_result)
+       data = sim_result,
+       date_range = params$date_range)
   
 }

--- a/tests/testthat/test-mcmc-augmented-data-update.R
+++ b/tests/testthat/test-mcmc-augmented-data-update.R
@@ -55,21 +55,21 @@ test_that("cascade resampling order calculated correctly", {
   is_date_connected <- model_info$is_date_connected[, , 2]
   shortest_paths <- model_info$shortest_paths[[2]]
   
-  ## anchor = 3
+  ## i = 3
   ## all correct, no cascade
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(FALSE, NA, FALSE, FALSE, NA),
                                 is_date_connected, shortest_paths),
     3)
   
-  ## anchor = 3
+  ## i = 3
   ## 3 (correct) only connected to a correct date, no cascade
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(FALSE, NA, FALSE, NA, NA),
                                 is_date_connected, shortest_paths),
     3)
   
-  ## anchor = 3
+  ## i = 3
   ## 3 (correct) --> 1 (erroneous) --> 4 (missing)
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(TRUE, NA, FALSE, NA, NA),
@@ -77,43 +77,45 @@ test_that("cascade resampling order calculated correctly", {
     c(3, 1, 4))
   
   ## same as above but 1 is missing instead (makes no difference)
-  ## anchor = 3
+  ## i = 3
   ## 3 (correct) --> 1 (missing) --> 4 (missing)
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(NA, NA, FALSE, NA, NA),
                                 is_date_connected, shortest_paths),
     c(3, 1, 4))
   
-  ## anchor = 3
+  ## i = 3
   ## 3 (correct) --> 1 (erroneous)
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(TRUE, NA, FALSE, FALSE, NA),
                                 is_date_connected, shortest_paths),
     c(3, 1))
   
-  ## anchor = 3
-  ## 3 (erroneous) cannot cascade as no correct dates
+  ## i = 3
+  ## no correct dates so cascade from 3
+  ## 3 (erroneous) --> 1 (missing) --> 4 (missing)
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(NA, NA, TRUE, NA, NA),
                                 is_date_connected, shortest_paths),
-    3)
+    c(3, 1, 4))
   
-  ## anchor = 3
+  ## i = 3
   ## 3 (erroneous) cannot cascade - only connected to 1 which is correct
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(FALSE, NA, TRUE, NA, NA),
                                 is_date_connected, shortest_paths),
     3)
   
+  ## i = 3
   ## anchor = 4 (nearest correct date to 3)
-  ## 1(missing) --> 3 (erroneous)
+  ## 1 (missing) --> 3 (erroneous)
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(NA, NA, TRUE, FALSE, NA),
                                 is_date_connected, shortest_paths),
     c(1, 3))
   
   
-  ## anchor = 1
+  ## i = 1
   ## 1 (correct) --> 3 (erroneous) and 1 --> 4 (missing)
   ## event order determines order in which we do those
   expect_equal(
@@ -121,30 +123,31 @@ test_that("cascade resampling order calculated correctly", {
                                 is_date_connected, shortest_paths),
     c(1, 3, 4))
   
-  ## anchor = 1
+  ## i = 1
   ## 1 (correct) --> 3 (erroneous)
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(FALSE, NA, TRUE, FALSE, NA),
                                 is_date_connected, shortest_paths),
     c(1, 3))
   
-  ## anchor = 1
-  ## 1 (erroneous), no cascade as all connected dates corret
+  ## i = 1
+  ## 1 (erroneous), no cascade as all connected dates correct
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, NA, FALSE, FALSE, NA),
                                 is_date_connected, shortest_paths),
     1)
   
-  ## anchor = 1
-  ## 1 (erroneous) cannot cascade as not connected to correct date
+  ## i = 1
+  ## cascade from 1 as no correct dates
+  ## 1 (erroneous) --> 3 (erroneous) --> 4 (missing)
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, NA, TRUE, NA, NA),
                                 is_date_connected, shortest_paths),
-    1)
+    c(1, 3, 4))
   
-  ## anchor = 1
+  ## i = 1
+  ## anchor = 3 (correct date connected to 1)
   ## 1 (erroneous) --> 4 (erroneous)
-  ## can cascade as 1 is connected to correct date 3
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, NA, FALSE, NA, NA),
                                 is_date_connected, shortest_paths),
@@ -158,7 +161,7 @@ test_that("cascade resampling order calculated correctly", {
   is_date_connected <- model_info$is_date_connected[, , 4]
   shortest_paths <- model_info$shortest_paths[[4]]
   
-  ## anchor = 1
+  ## i = 1
   ## all correct, no cascade
   expect_equal(
     calc_cascade_sampling_order(1, event_order, 
@@ -166,14 +169,14 @@ test_that("cascade resampling order calculated correctly", {
                                 is_date_connected, shortest_paths),
     1)
   
-  ## anchor = 1
+  ## i = 1
   ## 1 (correct) only connected to correct dates, no cascade
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(FALSE, FALSE, FALSE, NA, NA),
                                 is_date_connected, shortest_paths),
     1)
   
-  ## anchor = 1
+  ## i = 1
   ## 1 (correct) --> 2 (erroneous) and 1 --> 3 (missing)
   ## then 2 --> 4 (missing)
   expect_equal(
@@ -181,7 +184,7 @@ test_that("cascade resampling order calculated correctly", {
                                 is_date_connected, shortest_paths),
     c(1, 2, 3, 4))
   
-  ## anchor = 1
+  ## i = 1
   ## 1 (correct) --> 2 (erroneous) --> 4 (missing)
   ## no cascade to 3 (correct) 
   expect_equal(
@@ -197,6 +200,7 @@ test_that("cascade resampling order calculated correctly", {
                                 is_date_connected, shortest_paths),
     c(1, 3))
   
+  ## i = 1
   ## anchor = 4 (nearest correct date to 1)
   ## 2 (missing) --> 1 (erroneous) --> 3 (erroneous)
   expect_equal(
@@ -204,43 +208,43 @@ test_that("cascade resampling order calculated correctly", {
                                 is_date_connected, shortest_paths),
     c(2, 1, 3))
   
-  ## anchor = 1
+  ## i = 1
+  ## anchor = 3 (correct date connected to 1)
   ## 1 (erroneous) --> 2 (erroneous) --> 4 (missing)
-  ## can cascade as 1 (erroneous) connected to correct date 3
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, NA, FALSE, TRUE, NA),
                                 is_date_connected, shortest_paths),
     c(1, 2, 4))
   
-  ## anchor = 1
+  ## i = 1
+  ## anchor = 2 (correct date connected to 1)
   ## 1 (erroneous) --> 3 (missing)
-  ## can cascade as 1 (erroneous) connected to correct date 2
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, FALSE, NA, TRUE, NA),
                                 is_date_connected, shortest_paths),
     c(1, 3))
   
-  ## anchor = 2
+  
+  ## i = 2
   ## 2 (correct) --> 1 (erroneous) and 2 (correct) --> 4 (missing)
   ## then 1 (erroneous) --> 3 (missing)
-  ## can cascade as 1 (erroneous) connected to correct date 2
   expect_equal(
     calc_cascade_sampling_order(2, event_order, c(TRUE, FALSE, NA, NA, NA),
                                 is_date_connected, shortest_paths),
     c(2, 1, 4, 3))
   
   
-  ## anchor = 2
+  ## i = 2
+  ## anchor = 4 (correct date connected to 4)
   ## 2 (erroneous) --> 1 (erroneous) --> 3 (missing)
-  ## can cascade as 2 (erroneous) connected to correct date 4
   expect_equal(
     calc_cascade_sampling_order(2, event_order, c(TRUE, TRUE, NA, FALSE, NA),
                                 is_date_connected, shortest_paths),
     c(2, 1, 3))
   
-  ## anchor = 2
+  ## i = 2
+  ## anchor = 1 (correct date connected to 2)
   ## 2 (erroneous) --> 4 (erroneous)
-  ## can cascade as 2 (erroneous) connected to correct date 1
   expect_equal(
     calc_cascade_sampling_order(2, event_order, c(FALSE, TRUE, NA, TRUE, NA),
                                 is_date_connected, shortest_paths),
@@ -265,7 +269,7 @@ test_that("cascade resampling order calculated correctly", {
   expect_equal(
     calc_cascade_sampling_order(2, event_order, c(NA, TRUE, FALSE, NA),
                                 is_date_connected, shortest_paths),
-    2)
+    c(2, 4))
 })
 
 
@@ -474,6 +478,7 @@ test_that("estimated dates proposed correctly", {
   delay_map <- toy_model()$delay_map
   dates <- c("onset", "hospitalisation", "report", "death", "discharge")
   model_info <- make_model_info(delay_map, dates)
+  date_range <- toy_model()$date_range
   
   delay_pars <- list(list(mean = 8, shape = 4),
                      list(mean = 5, shape = 3),
@@ -493,7 +498,7 @@ test_that("estimated dates proposed correctly", {
                          error_indicators = c(NA, NA, FALSE, TRUE, NA))
   augmented_data_new <- 
     propose_estimated_dates(to_update, augmented_data, observed_dates, group,
-                            delay_pars, model_info, rng)
+                            delay_pars, model_info, date_range, rng)
   expect_equal(augmented_data$error_indicators,
                augmented_data_new$error_indicators)
   expect_equal(augmented_data$estimated_dates[-to_update],
@@ -511,14 +516,14 @@ test_that("estimated dates proposed correctly", {
                          error_indicators = c(NA, NA, FALSE, TRUE, NA))
   augmented_data_new <- 
     propose_estimated_dates(to_update, augmented_data, observed_dates, group,
-                            delay_pars, model_info, rng)
+                            delay_pars, model_info, date_range, rng)
   expect_equal(augmented_data$error_indicators,
                augmented_data_new$error_indicators)
   expect_equal(augmented_data$estimated_dates[-to_update],
                augmented_data_new$estimated_dates[-to_update])
   expect_equal(augmented_data_new$estimated_dates[to_update],
-               sample_from_delay(to_update, augmented_data_new,
-                                 group, delay_pars, model_info, rng1))
+               sample_from_delay(to_update, augmented_data_new, group,
+                                 delay_pars, model_info, date_range, rng1))
   
   
   ## group 2, propose all dates, swapping errors
@@ -533,7 +538,7 @@ test_that("estimated dates proposed correctly", {
                               model_info$is_date_connected[, , group])
   augmented_data_new <- 
     propose_estimated_dates(sampling_order, augmented_data, observed_dates,
-                            group, delay_pars, model_info, rng)
+                            group, delay_pars, model_info, date_range, rng)
   expect_equal(augmented_data_new$error_indicators, 
                augmented_data$error_indicators)
   cmp <- list(estimated_dates = rep(NA, 5),
@@ -542,9 +547,9 @@ test_that("estimated dates proposed correctly", {
   cmp$estimated_dates[4] <- observed_dates[4] + monty::monty_random_real(rng1)
   ## will then sample date 1 (connected to date 4) and then date 3
   cmp$estimated_dates[1] <- 
-    sample_from_delay(1, cmp, group, delay_pars, model_info, rng1)
+    sample_from_delay(1, cmp, group, delay_pars, model_info, date_range, rng1)
   cmp$estimated_dates[3] <- 
-    sample_from_delay(3, cmp, group, delay_pars, model_info, rng1)
+    sample_from_delay(3, cmp, group, delay_pars, model_info, date_range, rng1)
   expect_equal(augmented_data_new$estimated_dates, cmp$estimated_dates)
   
 })
@@ -555,6 +560,7 @@ test_that("proposal density calculated correctly", {
   delay_map <- toy_model()$delay_map
   dates <- c("onset", "hospitalisation", "report", "death", "discharge")
   model_info <- make_model_info(delay_map, dates)
+  date_range <- toy_model()$date_range
   
   delay_pars <- list(list(mean = 8, shape = 4),
                      list(mean = 5, shape = 3),
@@ -582,7 +588,7 @@ test_that("proposal density calculated correctly", {
               shape = delay_pars[[2]]$shape, 
               rate = delay_pars[[2]]$shape / delay_pars[[2]]$mean, log = TRUE)
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), d)
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
   
   ## group 2, updated missing onset date 
   ## based on delay 1 (gamma), onset (date 1) to report (date 3)
@@ -596,7 +602,7 @@ test_that("proposal density calculated correctly", {
            rate = c(delay_pars[[1]]$shape, delay_pars[[2]]$shape) /
              c(delay_pars[[1]]$mean, delay_pars[[2]]$mean)))) - log(2)
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), d)
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
   
   ## group 2, updated all dates
   ## report (date 3) is correct so has no impact for proposing this
@@ -604,7 +610,7 @@ test_that("proposal density calculated correctly", {
   ##               onset (date 1) to report (date 3)
   ## then death is proposed based on delay 2 (gamma),
   ##               onset (date 1) to death (date 4)
-  sampling_order <-
+  updated <-
     calc_batch_sampling_order(model_info$event_order[[group]],
                               augmented_data$error_indicators,
                               model_info$is_date_connected[, , group])
@@ -614,7 +620,8 @@ test_that("proposal density calculated correctly", {
                   rate = c(delay_pars[[1]]$shape, delay_pars[[2]]$shape) /
                     c(delay_pars[[1]]$mean, delay_pars[[2]]$mean), log = TRUE))
   expect_equal(calc_proposal_density(
-    sampling_order, augmented_data, group, delay_pars, model_info), d)
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
+    
   
   ## group 2, updated missing onset date 
   ## based on delay 1 (gamma), onset (date 1) to report (date 3)
@@ -630,7 +637,7 @@ test_that("proposal density calculated correctly", {
            rate = c(delay_pars[[1]]$shape, delay_pars[[2]]$shape) /
              c(delay_pars[[1]]$mean, delay_pars[[2]]$mean)))) - log(2)
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), d)
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
   
   ## group 2, updated missing onset date 
   ## based on delay 1 (gamma), onset (date 1) to report (date 3)
@@ -646,7 +653,31 @@ test_that("proposal density calculated correctly", {
            rate = c(delay_pars[[1]]$shape, delay_pars[[2]]$shape) /
              c(delay_pars[[1]]$mean, delay_pars[[2]]$mean)))) - log(2)
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), d)
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
+  
+  
+  ## group 2, updated all dates via cascade
+  ## no correct dates
+  ## start with report (date 3), no delay available so date proposed at random
+  ## then onset is proposed based on delay 1 (gamma), 
+  ##               onset (date 1) to report (date 3)
+  ## then death is proposed based on delay 2 (gamma),
+  ##               onset (date 1) to death (date 4)
+  augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
+                         error_indicators = c(NA, NA, TRUE, TRUE, NA))
+  updated <-
+    calc_cascade_sampling_order(3, model_info$event_order[[group]],
+                                augmented_data$error_indicators,
+                                model_info$is_date_connected[, , group],
+                                model_info$shortest_paths[[group]])
+  d <- -log(date_range[2] - date_range[1]) +
+    sum(dgamma(augmented_data$estimated_dates[c(3, 4)] - 
+                    augmented_data$estimated_dates[1],
+                  shape = c(delay_pars[[1]]$shape, delay_pars[[2]]$shape), 
+                  rate = c(delay_pars[[1]]$shape, delay_pars[[2]]$shape) /
+                    c(delay_pars[[1]]$mean, delay_pars[[2]]$mean), log = TRUE))
+  expect_equal(calc_proposal_density(
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
   
   
   # group 4, 3 dates
@@ -658,13 +689,13 @@ test_that("proposal density calculated correctly", {
   ## proposal log-density should be zero
   updated <- 1
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), 0)
+    updated, augmented_data, group, delay_pars, model_info, date_range), 0)
   
   ## group 4, updated correct report date
   ## proposal log-density should be zero
   updated <- 3
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), 0)
+    updated, augmented_data, group, delay_pars, model_info, date_range), 0)
   
   ## group 4, updated error hospitalisation date 
   ## based on delay 5 (log-normal), onset (date 1) to hospitalisation (date 2)
@@ -678,7 +709,7 @@ test_that("proposal density calculated correctly", {
            sdlog = 1 / sqrt(c(delay_pars[[5]]$precisionlog, 
                               delay_pars[[6]]$precisionlog))))) - log(2)
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), d)
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
   
   ## group 4, updated missing death date 
   ## based on delay 6 (log-normal), hospitalisation (date 2) to death (date 4)
@@ -688,7 +719,7 @@ test_that("proposal density calculated correctly", {
               meanlog = delay_pars[[6]]$meanlog, 
               sdlog = 1 / sqrt(delay_pars[[6]]$precisionlog), log = TRUE)
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), d)
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
   
   ## group 4, updated all dates
   ## onset (date 1) and report (date 3) correct so no impact for proposing
@@ -704,7 +735,7 @@ test_that("proposal density calculated correctly", {
                                      delay_pars[[6]]$precisionlog)),
                   log = TRUE))
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), d)
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
   
   
   ## group 4, updated error hospitalisation date 
@@ -721,7 +752,7 @@ test_that("proposal density calculated correctly", {
            sdlog = 1 / sqrt(c(delay_pars[[5]]$precisionlog, 
                               delay_pars[[6]]$precisionlog))))) - log(2)
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), d)
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
   
   
   ## group 4, updated error hospitalisation date 
@@ -738,7 +769,7 @@ test_that("proposal density calculated correctly", {
            sdlog = 1 / sqrt(c(delay_pars[[5]]$precisionlog, 
                               delay_pars[[6]]$precisionlog))))) - log(2)
   expect_equal(calc_proposal_density(
-    updated, augmented_data, group, delay_pars, model_info), d)
+    updated, augmented_data, group, delay_pars, model_info, date_range), d)
 })
 
 

--- a/tests/testthat/test-mcmc-augmented-data-update.R
+++ b/tests/testthat/test-mcmc-augmented-data-update.R
@@ -246,6 +246,26 @@ test_that("cascade resampling order calculated correctly", {
                                 is_date_connected, shortest_paths),
     c(2, 4))
   
+  
+  
+  ## special case where there are no paths between some dates
+  delay_map <- data.frame(
+    from = c("onset", "hospitalisation"),
+    to = c("report", "death"),
+    group = c(1, 1),
+    distribution = c("gamma", "gamma")
+  )
+  model_info <- 
+    make_model_info(delay_map, c("onset", "hospitalisation", "report", "death"))
+  
+  event_order <- model_info$event_order[[1]]
+  is_date_connected <- model_info$is_date_connected[, , 1]
+  shortest_paths <- model_info$shortest_paths[[1]]
+  ## 3 is only possible anchor but no path to it
+  expect_equal(
+    calc_cascade_sampling_order(2, event_order, c(NA, TRUE, FALSE, NA),
+                                is_date_connected, shortest_paths),
+    2)
 })
 
 

--- a/tests/testthat/test-mcmc-augmented-data-update.R
+++ b/tests/testthat/test-mcmc-augmented-data-update.R
@@ -586,13 +586,15 @@ test_that("proposal density calculated correctly", {
   
   ## group 2, updated missing onset date 
   ## based on delay 1 (gamma), onset (date 1) to report (date 3)
-  ## but not delay 2 (gamma), onset (date 1) to death (date 4)
-  ## because date 3 is correct and date 4 is not
+  ## and delay 2 (gamma), onset (date 1) to death (date 4)
+  ## the two delays are equally likely to be used
   updated <- 1
-  d <- dgamma(augmented_data$estimated_dates[3] - 
-                augmented_data$estimated_dates[1],
-              shape = delay_pars[[1]]$shape, 
-              rate = delay_pars[[1]]$shape / delay_pars[[1]]$mean, log = TRUE)
+  d <- log(sum(
+    dgamma(augmented_data$estimated_dates[c(3, 4)] - 
+             augmented_data$estimated_dates[1],
+           shape = c(delay_pars[[1]]$shape, delay_pars[[2]]$shape), 
+           rate = c(delay_pars[[1]]$shape, delay_pars[[2]]$shape) /
+             c(delay_pars[[1]]$mean, delay_pars[[2]]$mean)))) - log(2)
   expect_equal(calc_proposal_density(
     updated, augmented_data, group, delay_pars, model_info), d)
   
@@ -617,7 +619,7 @@ test_that("proposal density calculated correctly", {
   ## group 2, updated missing onset date 
   ## based on delay 1 (gamma), onset (date 1) to report (date 3)
   ## and delay 2 (gamma), onset (date 1) to death (date 4)
-  ## the two delays are equally likely to be used as dates 3 and 4 both correct
+  ## the two delays are equally likely to be used
   augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
                          error_indicators = c(NA, NA, FALSE, FALSE, NA))
   updated <- 1
@@ -633,7 +635,7 @@ test_that("proposal density calculated correctly", {
   ## group 2, updated missing onset date 
   ## based on delay 1 (gamma), onset (date 1) to report (date 3)
   ## and delay 2 (gamma), onset (date 1) to death (date 4)
-  ## the two delays are equally likely to be used as dates 3 and 4 both error
+  ## the two delays are equally likely to be used
   augmented_data <- list(estimated_dates = c(20.5, NA, 40.2, 50.1, NA),
                          error_indicators = c(NA, NA, FALSE, FALSE, NA))
   updated <- 1
@@ -666,13 +668,15 @@ test_that("proposal density calculated correctly", {
   
   ## group 4, updated error hospitalisation date 
   ## based on delay 5 (log-normal), onset (date 1) to hospitalisation (date 2)
-  ## but not delay 6 (log-normal), hospitalisation (date 2) to death (date 4)
-  ## because date 1 is correct and date 4 is missing
+  ## and delay 6 (log-normal), hospitalisation (date 2) to death (date 4)
+  ## the two delays are equally likely to be used
   updated <- 2
-  d <- dlnorm(augmented_data$estimated_dates[2] - 
-                augmented_data$estimated_dates[1],
-              meanlog = delay_pars[[5]]$meanlog, 
-              sdlog = 1 / sqrt(delay_pars[[5]]$precisionlog), log = TRUE)
+  d <- log(sum(
+    dlnorm(augmented_data$estimated_dates[c(2, 4)] - 
+             augmented_data$estimated_dates[c(1, 2)],
+           meanlog = c(delay_pars[[5]]$meanlog, delay_pars[[6]]$meanlog), 
+           sdlog = 1 / sqrt(c(delay_pars[[5]]$precisionlog, 
+                              delay_pars[[6]]$precisionlog))))) - log(2)
   expect_equal(calc_proposal_density(
     updated, augmented_data, group, delay_pars, model_info), d)
   
@@ -707,7 +711,6 @@ test_that("proposal density calculated correctly", {
   ## based on delay 5 (log-normal), onset (date 1) to hospitalisation (date 2)
   ## and delay 6 (log-normal), hospitalisation (date 2) to death (date 4)
   ## the two delays are equally likely to be used
-  ## because both date 1 and 4 are correct
   updated <- 2
   augmented_data <- list(estimated_dates = c(10.3, 15.4, 30.2, 40.1, NA),
                          error_indicators = c(FALSE, TRUE, FALSE, FALSE, NA))
@@ -725,7 +728,6 @@ test_that("proposal density calculated correctly", {
   ## based on delay 5 (log-normal), onset (date 1) to hospitalisation (date 2)
   ## and delay 6 (log-normal), hospitalisation (date 2) to death (date 4)
   ## the two delays are equally likely to be used
-  ## because neither date 1 nor 4 are correct
   updated <- 2
   augmented_data <- list(estimated_dates = c(10.3, 15.4, 30.2, 40.1, NA),
                          error_indicators = c(TRUE, TRUE, FALSE, NA, NA))

--- a/tests/testthat/test-mcmc-augmented-data-update.R
+++ b/tests/testthat/test-mcmc-augmented-data-update.R
@@ -53,26 +53,27 @@ test_that("cascade resampling order calculated correctly", {
   
   event_order <- model_info$event_order[[2]]
   is_date_connected <- model_info$is_date_connected[, , 2]
+  shortest_paths <- model_info$shortest_paths[[2]]
   
   ## anchor = 3
   ## all correct, no cascade
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(FALSE, NA, FALSE, FALSE, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     3)
   
   ## anchor = 3
   ## 3 (correct) only connected to a correct date, no cascade
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(FALSE, NA, FALSE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     3)
   
   ## anchor = 3
   ## 3 (correct) --> 1 (erroneous) --> 4 (missing)
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(TRUE, NA, FALSE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(3, 1, 4))
   
   ## same as above but 1 is missing instead (makes no difference)
@@ -80,30 +81,36 @@ test_that("cascade resampling order calculated correctly", {
   ## 3 (correct) --> 1 (missing) --> 4 (missing)
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(NA, NA, FALSE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(3, 1, 4))
   
   ## anchor = 3
   ## 3 (correct) --> 1 (erroneous)
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(TRUE, NA, FALSE, FALSE, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(3, 1))
   
   ## anchor = 3
-  ## 3 (erroneous) cannot cascade as not connected to a correct date
+  ## 3 (erroneous) cannot cascade as no correct dates
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(NA, NA, TRUE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     3)
   
-  ## same as above but 1 is correct (makes no difference)
   ## anchor = 3
-  ## 3 (erroneous) cannot cascade
+  ## 3 (erroneous) cannot cascade - only connected to 1 which is correct
   expect_equal(
     calc_cascade_sampling_order(3, event_order, c(FALSE, NA, TRUE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     3)
+  
+  ## anchor = 4 (nearest correct date to 3)
+  ## 1(missing) --> 3 (erroneous)
+  expect_equal(
+    calc_cascade_sampling_order(3, event_order, c(NA, NA, TRUE, FALSE, NA),
+                                is_date_connected, shortest_paths),
+    c(1, 3))
   
   
   ## anchor = 1
@@ -111,28 +118,28 @@ test_that("cascade resampling order calculated correctly", {
   ## event order determines order in which we do those
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(FALSE, NA, TRUE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(1, 3, 4))
   
   ## anchor = 1
   ## 1 (correct) --> 3 (erroneous)
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(FALSE, NA, TRUE, FALSE, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(1, 3))
   
   ## anchor = 1
   ## 1 (erroneous), no cascade as all connected dates corret
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, NA, FALSE, FALSE, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     1)
   
   ## anchor = 1
   ## 1 (erroneous) cannot cascade as not connected to correct date
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, NA, TRUE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     1)
   
   ## anchor = 1
@@ -140,7 +147,7 @@ test_that("cascade resampling order calculated correctly", {
   ## can cascade as 1 is connected to correct date 3
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, NA, FALSE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(1, 4))
   
   
@@ -149,20 +156,21 @@ test_that("cascade resampling order calculated correctly", {
   
   event_order <- model_info$event_order[[4]]
   is_date_connected <- model_info$is_date_connected[, , 4]
+  shortest_paths <- model_info$shortest_paths[[4]]
   
   ## anchor = 1
   ## all correct, no cascade
   expect_equal(
     calc_cascade_sampling_order(1, event_order, 
                                 c(FALSE, FALSE, FALSE, FALSE, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     1)
   
   ## anchor = 1
   ## 1 (correct) only connected to correct dates, no cascade
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(FALSE, FALSE, FALSE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     1)
   
   ## anchor = 1
@@ -170,7 +178,7 @@ test_that("cascade resampling order calculated correctly", {
   ## then 2 --> 4 (missing)
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(FALSE, TRUE, NA, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(1, 2, 3, 4))
   
   ## anchor = 1
@@ -178,7 +186,7 @@ test_that("cascade resampling order calculated correctly", {
   ## no cascade to 3 (correct) 
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(FALSE, TRUE, FALSE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(1, 2, 4))
   
   ## anchor = 1
@@ -186,22 +194,22 @@ test_that("cascade resampling order calculated correctly", {
   ## no cascade to 2 (correct) 
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(FALSE, FALSE, TRUE, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(1, 3))
   
-  ## anchor = 1
-  ## cannot cascade as 1 (erroneous) not connected to a correct date
+  ## anchor = 4 (nearest correct date to 1)
+  ## 2 (missing) --> 1 (erroneous) --> 3 (erroneous)
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, NA, TRUE, FALSE, NA),
-                                is_date_connected),
-    1)
+                                is_date_connected, shortest_paths),
+    c(2, 1, 3))
   
   ## anchor = 1
   ## 1 (erroneous) --> 2 (erroneous) --> 4 (missing)
   ## can cascade as 1 (erroneous) connected to correct date 3
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, NA, FALSE, TRUE, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(1, 2, 4))
   
   ## anchor = 1
@@ -209,7 +217,7 @@ test_that("cascade resampling order calculated correctly", {
   ## can cascade as 1 (erroneous) connected to correct date 2
   expect_equal(
     calc_cascade_sampling_order(1, event_order, c(TRUE, FALSE, NA, TRUE, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(1, 3))
   
   ## anchor = 2
@@ -218,7 +226,7 @@ test_that("cascade resampling order calculated correctly", {
   ## can cascade as 1 (erroneous) connected to correct date 2
   expect_equal(
     calc_cascade_sampling_order(2, event_order, c(TRUE, FALSE, NA, NA, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(2, 1, 4, 3))
   
   
@@ -227,7 +235,7 @@ test_that("cascade resampling order calculated correctly", {
   ## can cascade as 2 (erroneous) connected to correct date 4
   expect_equal(
     calc_cascade_sampling_order(2, event_order, c(TRUE, TRUE, NA, FALSE, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(2, 1, 3))
   
   ## anchor = 2
@@ -235,7 +243,7 @@ test_that("cascade resampling order calculated correctly", {
   ## can cascade as 2 (erroneous) connected to correct date 1
   expect_equal(
     calc_cascade_sampling_order(2, event_order, c(FALSE, TRUE, NA, TRUE, NA),
-                                is_date_connected),
+                                is_date_connected, shortest_paths),
     c(2, 4))
   
 })

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -17,7 +17,8 @@ test_that("model info is setup correctly", {
   expect_equal(names(model_info),
                c("delay_from", "delay_to", "delay_distribution",
                  "is_delay_in_group", "is_date_in_delay", "is_date_in_group",
-                 "is_date_connected", "event_order", "groups"))
+                 "is_date_connected", "event_order", "shortest_paths", 
+                 "groups"))
   
   delay_from <- c(1, 1, 1, 2, 1, 2)
   delay_to <- c(3, 4, 2, 5, 2, 4)
@@ -86,6 +87,31 @@ test_that("model info is setup correctly", {
                     c(1, 2, 3, 5),
                     c(1, 2, 3, 4)))
   
+  shortest_paths <- rep(list(rep(list(NULL), 5)), 4)
+  # group 1, onset/report
+  shortest_paths[[1]][[1]] <- list(NULL, NULL, c(1, 3), NULL, NULL)
+  shortest_paths[[1]][[3]] <- list(c(3, 1), NULL, NULL, NULL, NULL)
+  # group 2, onset/death/report
+  shortest_paths[[2]][[1]] <- list(NULL, NULL, c(1, 3), c(1, 4), NULL)
+  shortest_paths[[2]][[3]] <- list(c(3, 1), NULL, NULL, c(3, 1, 4), NULL)
+  shortest_paths[[2]][[4]] <- list(c(4, 1), NULL, c(4, 1, 3), NULL, NULL)
+  # group 3, onset/hospitalisation/discharge/report
+  shortest_paths[[3]][[1]] <- list(NULL, c(1, 2), c(1, 3), NULL, c(1, 2, 5))
+  shortest_paths[[3]][[2]] <- list(c(2, 1), NULL, c(2, 1, 3), NULL, c(2, 5))
+  shortest_paths[[3]][[3]] <- 
+    list(c(3, 1), c(3, 1, 2), NULL, NULL, c(3, 1, 2, 5))
+  shortest_paths[[3]][[5]] <- 
+    list(c(5, 2, 1), c(5, 2), c(5, 2, 1, 3), NULL, NULL)
+  # group 4, onset/hospitalisation/death/report
+  shortest_paths[[4]][[1]] <- list(NULL, c(1, 2), c(1, 3), c(1, 2, 4), NULL)
+  shortest_paths[[4]][[2]] <- list(c(2, 1), NULL, c(2, 1, 3), c(2, 4), NULL)
+  shortest_paths[[4]][[3]] <- 
+    list(c(3, 1), c(3, 1, 2), NULL, c(3, 1, 2, 4), NULL)
+  shortest_paths[[4]][[4]] <- 
+    list(c(4, 2, 1), c(4, 2), c(4, 2, 1, 3), NULL, NULL)
+  expect_equal(model_info$shortest_paths,
+               shortest_paths)
+  
   
   ## now setup with named groups
   groups <- c("community_alive", "community_dead", "hospitalised_alive",
@@ -137,6 +163,7 @@ test_that("model info is setup correctly", {
   expect_equal(model_info3$is_date_connected[, , g],
                model_info$is_date_connected)
   expect_equal(model_info3$event_order[g], model_info$event_order)
+  expect_equal(model_info3$shortest_paths[g], model_info$shortest_paths)
 })
 
 


### PR DESCRIPTION
This incorporates several improvements to the augmented data updates

- Cascade is now used for update_estimated_dates and not just update_error_indicators
- Previously we could only cascade from a correct date, or if an erroneous/missing date was connected to a correct date. Now we find the nearest correct date and then cascade from there. If there is no path to a correct date, then we sample the erroneous/missing date of interest uniformly at random from the date range and then cascade from there.
- Previously when sampling an erroneous/missing date based on delays, if there were available delays where the other date is correct then we would only use these. We now use all available delays irrespective of whether the other date is correct/erroneous/missing